### PR TITLE
Migrate kapt to ksp

### DIFF
--- a/backintime-compiler/build.gradle.kts
+++ b/backintime-compiler/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlinJvm)
-    alias(libs.plugins.kotlinKapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinSerialization)
     `maven-publish`
 }
@@ -12,7 +12,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     compileOnly(libs.auto.service)
-    kapt(libs.auto.service)
+    ksp(libs.auto.service.ksp)
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).all {

--- a/backintime-gradle-plugin/build.gradle.kts
+++ b/backintime-gradle-plugin/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlinJvm)
-    alias(libs.plugins.kotlinKapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinSerialization)
     `java-gradle-plugin`
     `maven-publish`
@@ -21,6 +21,6 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     compileOnly(libs.auto.service)
-    kapt(libs.auto.service)
+    ksp(libs.auto.service.ksp)
     compileOnly(kotlin("gradle-plugin"))
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlinJvm) apply false
-    alias(libs.plugins.kotlinKapt) apply false
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kotlinSerialization) apply false
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlinJvm) apply false
-    alias(libs.plugins.kotlinKapt) apply false
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kotlinSerialization) apply false
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ flipper = "0.233.0"
 kotlinx-coroutines = "1.7.3"
 kotlinx-serialization-json = "1.6.2"
 auto-service = "1.1.1"
+auto-service-ksp = "1.1.0"
 androidx-core = "1.12.0"
 androidx-lifecycle = "2.7.0"
 androidx-compose = "1.6.0"
@@ -10,6 +11,7 @@ robolectric = "4.11.1"
 mockk = "1.13.8"
 kotlin = "1.9.22"
 android-library = "8.2.2"
+ksp = "1.9.22-1.0.17"
 
 [libraries]
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
@@ -21,6 +23,7 @@ kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit"
 flipper = { module = "com.facebook.flipper:flipper", version.ref = "flipper" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 auto-service = { group = "com.google.auto.service", name = "auto-service", version.ref = "auto-service" }
+auto-service-ksp = { group = "dev.zacsweers.autoservice", name = "auto-service-ksp", version.ref = "auto-service-ksp" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core" }
@@ -36,4 +39,4 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 androidLibrary = { id = "com.android.library", version.ref = "android-library" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-kotlinKapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
Official implementation of auto-service depends on kapt. But ksp version is available at https://github.com/ZacSweers/auto-service-ksp.

replace with it, and remove kapt plugin completely.