### PR TITLE
Refactor debug events

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ class CounterViewModel : BackInTimeDebuggable {
     // other required properties for debugging...
 
     init {
-        BackInTimeDebugService.emitEvent(DebuggableStateHolderEvent.Register(...))
+        BackInTimeDebugService.emitEvent(DebuggableStateHolderEvent.RegisterInstance(...))
     }
 
     fun increment() {

--- a/README.md
+++ b/README.md
@@ -140,14 +140,14 @@ class CounterViewModel : BackInTimeDebuggable {
     // other required properties for debugging...
 
     init {
-        BackInTimeDebugService.emitEvent(BackInTimeDebugServiceEvent.Register(...))
+        BackInTimeDebugService.emitEvent(DebuggableStateHolderEvent.Register(...))
     }
 
     fun increment() {
         val callUUID = UUID.randomUUID().toString()
-        BackInTimeDebugService.emitEvent(BackInTimeDebugServiceEvent.MethodCall(...))
+        BackInTimeDebugService.emitEvent(DebuggableStateHolderEvent.MethodCall(...))
         count++
-        BackInTimeDebugService.emitEvent(BackInTimeDebugServiceEvent.PropertyValueChange(...))
+        BackInTimeDebugService.emitEvent(DebuggableStateHolderEvent.PropertyValueChange(...))
     }
 
     fun forceSetValue(propertyName: String, value: Any?) {

--- a/backintime-compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/BackInTimePluginContext.kt
+++ b/backintime-compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/BackInTimePluginContext.kt
@@ -1,8 +1,8 @@
 package com.github.kitakkun.backintime.compiler.backend
 
+import com.github.kitakkun.backintime.compiler.backend.analyzer.UserDefinedValueContainerAnalyzer
 import com.github.kitakkun.backintime.compiler.configuration.BackInTimeCompilerConfiguration
 import com.github.kitakkun.backintime.compiler.consts.BackInTimeConsts
-import com.github.kitakkun.backintime.compiler.backend.analyzer.UserDefinedValueContainerAnalyzer
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.jvm.ir.isReifiable
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
@@ -26,8 +26,8 @@ class BackInTimePluginContext(
     // BackInTimeDebugService
     val backInTimeServiceClassSymbol = referenceClass(BackInTimeConsts.backInTimeDebugServiceClassId)!!
 
-    // BackInTimeDebugServiceEvent
-    private val backInTimeServiceEventClassSymbol = referenceClass(BackInTimeConsts.backInTimeDebugServiceEventClassId)!!
+    // DebuggableStateHolderEvent
+    private val backInTimeServiceEventClassSymbol = referenceClass(BackInTimeConsts.debuggableStateHolderEventClassId)!!
     private val backInTimeServiceEventSealedSubClasses = backInTimeServiceEventClassSymbol.owner.sealedSubclasses
     val emitEventFunctionSymbol = backInTimeServiceClassSymbol.getSimpleFunction("emitEvent")!!
     val registerInstanceEventConstructorSymbol = backInTimeServiceEventSealedSubClasses.first { it.owner.classId == BackInTimeConsts.registerEventClassId }.constructors.first { it.owner.isPrimary }

--- a/backintime-compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/consts/BackInTimeConsts.kt
+++ b/backintime-compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/consts/BackInTimeConsts.kt
@@ -16,11 +16,11 @@ object BackInTimeConsts {
     val backInTimeInitializedPropertyMapName = Name.identifier("backInTimeInitializedPropertyMap")
 
     val backInTimeDebugServiceClassId = classId("com.github.kitakkun.backintime.runtime", "BackInTimeDebugService")
-    val backInTimeDebugServiceEventClassId = classId("com.github.kitakkun.backintime.runtime", "BackInTimeDebugServiceEvent")
-    val registerEventClassId = backInTimeDebugServiceEventClassId.createNestedClassId(Name.identifier("RegisterInstance"))
-    val registerRelationshipEventClassId = backInTimeDebugServiceEventClassId.createNestedClassId(Name.identifier("RegisterRelationShip"))
-    val methodCallEventClassId = backInTimeDebugServiceEventClassId.createNestedClassId(Name.identifier("MethodCall"))
-    val propertyValueChangeEventClassId = backInTimeDebugServiceEventClassId.createNestedClassId(Name.identifier("PropertyValueChange"))
+    val debuggableStateHolderEventClassId = classId("com.github.kitakkun.backintime.runtime", "DebuggableStateHolderEvent")
+    val registerEventClassId = debuggableStateHolderEventClassId.createNestedClassId(Name.identifier("RegisterInstance"))
+    val registerRelationshipEventClassId = debuggableStateHolderEventClassId.createNestedClassId(Name.identifier("RegisterRelationShip"))
+    val methodCallEventClassId = debuggableStateHolderEventClassId.createNestedClassId(Name.identifier("MethodCall"))
+    val propertyValueChangeEventClassId = debuggableStateHolderEventClassId.createNestedClassId(Name.identifier("PropertyValueChange"))
     val printlnCallableId = CallableId(FqName("kotlin.io"), Name.identifier("println"))
 
     val instanceInfoClassId = classId("com.github.kitakkun.backintime.runtime", "InstanceInfo")

--- a/backintime-runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/BackInTimeDebugService.kt
+++ b/backintime-runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/BackInTimeDebugService.kt
@@ -1,5 +1,6 @@
 package com.github.kitakkun.backintime.runtime
 
+import com.github.kitakkun.backintime.runtime.event.BackInTimeDebugServiceEvent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -7,7 +8,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.SerializationException
-import java.util.PriorityQueue
 import java.util.WeakHashMap
 import kotlin.coroutines.CoroutineContext
 
@@ -20,22 +20,13 @@ object BackInTimeDebugService : CoroutineScope {
 
     private val instances = WeakHashMap<BackInTimeDebuggable, String>()
 
-    private val mutableRegisteredInstanceFlow = MutableSharedFlow<InstanceInfo>()
-    val registeredInstanceFlow = mutableRegisteredInstanceFlow.asSharedFlow()
-
-    private val mutableRegisterRelationshipFlow = MutableSharedFlow<RelationshipInfo>()
-    val registerRelationshipFlow = mutableRegisterRelationshipFlow.asSharedFlow()
-
-    private val mutableNotifyValueChangeFlow = MutableSharedFlow<ValueChangeInfo>()
-    val notifyValueChangeFlow = mutableNotifyValueChangeFlow.asSharedFlow()
-
-    private val mutableNotifyMethodCallFlow = MutableSharedFlow<MethodCallInfo>()
-    val notifyMethodCallFlow = mutableNotifyMethodCallFlow.asSharedFlow()
+    private val mutableServiceEventFlow = MutableSharedFlow<BackInTimeDebugServiceEvent>()
+    val serviceEventFlow = mutableServiceEventFlow.asSharedFlow()
 
     private val mutableInternalErrorFlow = MutableSharedFlow<Throwable>()
     val internalErrorFlow = mutableInternalErrorFlow.asSharedFlow()
 
-    private val internalEventQueue = PriorityQueue<DebuggableStateHolderEvent> { event1, event2 -> event1.priority - event2.priority }
+    private val internalServiceEventQueue = mutableListOf<BackInTimeDebugServiceEvent>()
     private var isConnected: Boolean = false
 
     /**
@@ -44,8 +35,8 @@ object BackInTimeDebugService : CoroutineScope {
      */
     fun start() {
         isConnected = true
-        internalEventQueue.forEach(::processEvent)
-        internalEventQueue.clear()
+        internalServiceEventQueue.forEach { event -> launch { mutableServiceEventFlow.emit(event) } }
+        internalServiceEventQueue.clear()
     }
 
     /**
@@ -62,20 +53,19 @@ object BackInTimeDebugService : CoroutineScope {
      * @param event event to be sent
      */
     fun emitEvent(event: DebuggableStateHolderEvent) {
-        if (!isConnected) {
-            internalEventQueue.add(event)
-            return
-        }
-
-        processEvent(event)
-    }
-
-    private fun processEvent(event: DebuggableStateHolderEvent) {
-        when (event) {
+        val result = when (event) {
             is DebuggableStateHolderEvent.RegisterInstance -> register(event)
             is DebuggableStateHolderEvent.RegisterRelationShip -> registerRelationship(event)
             is DebuggableStateHolderEvent.MethodCall -> notifyMethodCall(event)
             is DebuggableStateHolderEvent.PropertyValueChange -> notifyPropertyChanged(event)
+        }
+
+        if (result != null) {
+            if (isConnected) {
+                launch { mutableServiceEventFlow.emit(result) }
+            } else {
+                internalServiceEventQueue.add(result)
+            }
         }
     }
 
@@ -83,57 +73,50 @@ object BackInTimeDebugService : CoroutineScope {
      * register instance for debugging
      * if the instance is garbage collected, it will be automatically removed from the list.
      */
-    private fun register(event: DebuggableStateHolderEvent.RegisterInstance) {
+    private fun register(event: DebuggableStateHolderEvent.RegisterInstance): BackInTimeDebugServiceEvent {
         // When the instance of subclass is registered, it overrides the instance of superclass.
         instances[event.instance] = event.instance.backInTimeInstanceUUID
-        launch {
-            mutableRegisteredInstanceFlow.emit(event.info)
-        }
+        return BackInTimeDebugServiceEvent.RegisterInstance(
+            instanceUUID = event.instance.backInTimeInstanceUUID,
+            className = event.info.type,
+            superClassName = event.info.superType,
+            properties = event.info.properties,
+            registeredAt = System.currentTimeMillis(),
+        )
     }
 
-    private fun registerRelationship(event: DebuggableStateHolderEvent.RegisterRelationShip) {
-        launch {
-            mutableRegisterRelationshipFlow.emit(
-                RelationshipInfo(
-                    from = event.parentInstance.backInTimeInstanceUUID,
-                    to = event.childInstance.backInTimeInstanceUUID,
-                )
-            )
-        }
+    private fun registerRelationship(event: DebuggableStateHolderEvent.RegisterRelationShip): BackInTimeDebugServiceEvent {
+        return BackInTimeDebugServiceEvent.RegisterRelationship(
+            parentUUID = event.parentInstance.backInTimeInstanceUUID,
+            childUUID = event.childInstance.backInTimeInstanceUUID,
+        )
     }
 
-    private fun notifyMethodCall(event: DebuggableStateHolderEvent.MethodCall) {
-        val instanceId = instances[event.instance] ?: return
-        launch {
-            mutableNotifyMethodCallFlow.emit(
-                MethodCallInfo(
-                    instanceUUID = instanceId,
-                    methodName = event.methodName,
-                    methodCallUUID = event.methodCallId,
-                    calledAt = System.currentTimeMillis(),
-                )
-            )
-        }
+    private fun notifyMethodCall(event: DebuggableStateHolderEvent.MethodCall): BackInTimeDebugServiceEvent? {
+        val instanceId = instances[event.instance] ?: return null
+        return BackInTimeDebugServiceEvent.NotifyMethodCall(
+            instanceUUID = instanceId,
+            methodName = event.methodName,
+            methodCallUUID = event.methodCallId,
+            calledAt = System.currentTimeMillis(),
+        )
     }
 
-    private fun notifyPropertyChanged(event: DebuggableStateHolderEvent.PropertyValueChange) {
-        val instanceUUID = instances[event.instance] ?: return
-        try {
+    private fun notifyPropertyChanged(event: DebuggableStateHolderEvent.PropertyValueChange): BackInTimeDebugServiceEvent? {
+        val instanceUUID = instances[event.instance] ?: return null
+        return try {
             val serializedValue = event.instance.serializeValue(event.propertyName, event.propertyValue)
-            launch {
-                mutableNotifyValueChangeFlow.emit(
-                    ValueChangeInfo(
-                        instanceUUID = instanceUUID,
-                        propertyName = event.propertyName,
-                        value = serializedValue,
-                        methodCallUUID = event.methodCallId,
-                    )
-                )
-            }
+            BackInTimeDebugServiceEvent.NotifyValueChange(
+                instanceUUID = instanceUUID,
+                propertyName = event.propertyName,
+                value = serializedValue,
+                methodCallUUID = event.methodCallId,
+            )
         } catch (e: SerializationException) {
             launch {
                 mutableInternalErrorFlow.emit(e)
             }
+            null
         }
     }
 

--- a/backintime-runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/DebuggableStateHolderEvent.kt
+++ b/backintime-runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/DebuggableStateHolderEvent.kt
@@ -1,25 +1,20 @@
 package com.github.kitakkun.backintime.runtime
 
 sealed interface DebuggableStateHolderEvent {
-    val priority: Int
-
     data class RegisterInstance(
         val instance: BackInTimeDebuggable,
         val info: InstanceInfo,
-        override val priority: Int = 0,
     ) : DebuggableStateHolderEvent
 
     data class RegisterRelationShip(
         val parentInstance: BackInTimeDebuggable,
         val childInstance: BackInTimeDebuggable,
-        override val priority: Int = 1,
     ) : DebuggableStateHolderEvent
 
     data class MethodCall(
         val instance: BackInTimeDebuggable,
         val methodCallId: String,
         val methodName: String,
-        override val priority: Int = 1,
     ) : DebuggableStateHolderEvent
 
     data class PropertyValueChange(
@@ -27,6 +22,5 @@ sealed interface DebuggableStateHolderEvent {
         val methodCallId: String,
         val propertyName: String,
         val propertyValue: Any?,
-        override val priority: Int = 2,
     ) : DebuggableStateHolderEvent
 }

--- a/backintime-runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/DebuggableStateHolderEvent.kt
+++ b/backintime-runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/DebuggableStateHolderEvent.kt
@@ -1,26 +1,26 @@
 package com.github.kitakkun.backintime.runtime
 
-sealed interface BackInTimeDebugServiceEvent {
+sealed interface DebuggableStateHolderEvent {
     val priority: Int
 
     data class RegisterInstance(
         val instance: BackInTimeDebuggable,
         val info: InstanceInfo,
         override val priority: Int = 0,
-    ) : BackInTimeDebugServiceEvent
+    ) : DebuggableStateHolderEvent
 
     data class RegisterRelationShip(
         val parentInstance: BackInTimeDebuggable,
         val childInstance: BackInTimeDebuggable,
         override val priority: Int = 1,
-    ) : BackInTimeDebugServiceEvent
+    ) : DebuggableStateHolderEvent
 
     data class MethodCall(
         val instance: BackInTimeDebuggable,
         val methodCallId: String,
         val methodName: String,
         override val priority: Int = 1,
-    ) : BackInTimeDebugServiceEvent
+    ) : DebuggableStateHolderEvent
 
     data class PropertyValueChange(
         val instance: BackInTimeDebuggable,
@@ -28,5 +28,5 @@ sealed interface BackInTimeDebugServiceEvent {
         val propertyName: String,
         val propertyValue: Any?,
         override val priority: Int = 2,
-    ) : BackInTimeDebugServiceEvent
+    ) : DebuggableStateHolderEvent
 }

--- a/backintime-runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/event/BackInTimeDebugServiceEvent.kt
+++ b/backintime-runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/event/BackInTimeDebugServiceEvent.kt
@@ -1,12 +1,13 @@
-package com.github.kitakkun.backintime.runtime.flipper.events
+package com.github.kitakkun.backintime.runtime.event
 
 import com.github.kitakkun.backintime.runtime.PropertyInfo
 import kotlinx.serialization.Serializable
 
 /**
- * Mobile app -> Desktop app
+ * events from debugService to debugger
  */
-sealed interface FlipperOutgoingEvent {
+@Serializable
+sealed interface BackInTimeDebugServiceEvent {
     @Serializable
     data class RegisterInstance(
         val instanceUUID: String,
@@ -14,11 +15,7 @@ sealed interface FlipperOutgoingEvent {
         val superClassName: String,
         val properties: List<PropertyInfo>,
         val registeredAt: Long,
-    ) : FlipperOutgoingEvent {
-        companion object {
-            const val EVENT_NAME = "register"
-        }
-    }
+    ) : BackInTimeDebugServiceEvent
 
     @Serializable
     data class NotifyValueChange(
@@ -26,11 +23,7 @@ sealed interface FlipperOutgoingEvent {
         val propertyName: String,
         val value: String,
         val methodCallUUID: String,
-    ) : FlipperOutgoingEvent {
-        companion object {
-            const val EVENT_NAME = "notifyValueChange"
-        }
-    }
+    ) : BackInTimeDebugServiceEvent
 
     @Serializable
     data class NotifyMethodCall(
@@ -38,19 +31,11 @@ sealed interface FlipperOutgoingEvent {
         val methodName: String,
         val methodCallUUID: String,
         val calledAt: Long,
-    ) : FlipperOutgoingEvent {
-        companion object {
-            const val EVENT_NAME = "notifyMethodCall"
-        }
-    }
+    ) : BackInTimeDebugServiceEvent
 
     @Serializable
     data class RegisterRelationship(
         val parentUUID: String,
         val childUUID: String,
-    ) : FlipperOutgoingEvent {
-        companion object {
-            const val EVENT_NAME = "registerRelationship"
-        }
-    }
+    ) : BackInTimeDebugServiceEvent
 }

--- a/backintime-runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/event/BackInTimeDebuggerEvent.kt
+++ b/backintime-runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/event/BackInTimeDebuggerEvent.kt
@@ -1,19 +1,16 @@
-package com.github.kitakkun.backintime.runtime.flipper.events
+package com.github.kitakkun.backintime.runtime.event
 
 import kotlinx.serialization.Serializable
 
 /**
- * Desktop app -> Mobile app
+ * events from debugger to debugService
  */
-sealed interface FlipperIncomingEvent {
+@Serializable
+sealed interface BackInTimeDebuggerEvent {
     @Serializable
     data class CheckInstanceAlive(
         val instanceUUIDs: List<String>,
-    ) : FlipperIncomingEvent {
-        companion object {
-            const val EVENT_NAME = "refreshInstanceAliveStatus"
-        }
-
+    ) : BackInTimeDebuggerEvent {
         @Serializable
         data class Response(
             val isAlive: Map<String, Boolean>,
@@ -26,9 +23,5 @@ sealed interface FlipperIncomingEvent {
         val propertyName: String,
         val value: String,
         val valueType: String,
-    ) : FlipperIncomingEvent {
-        companion object {
-            const val EVENT_NAME = "forceSetPropertyValue"
-        }
-    }
+    ) : BackInTimeDebuggerEvent
 }

--- a/test/src/androidDebugUnitTest/kotlin/com/github/kitakkun/backintime/test/BackInTimeDebugServiceTest.kt
+++ b/test/src/androidDebugUnitTest/kotlin/com/github/kitakkun/backintime/test/BackInTimeDebugServiceTest.kt
@@ -1,7 +1,7 @@
 package com.github.kitakkun.backintime.test
 
 import com.github.kitakkun.backintime.runtime.BackInTimeDebugService
-import com.github.kitakkun.backintime.runtime.BackInTimeDebugServiceEvent
+import com.github.kitakkun.backintime.runtime.DebuggableStateHolderEvent
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.slot
@@ -17,14 +17,14 @@ import kotlin.test.BeforeTest
 @RunWith(RobolectricTestRunner::class)
 abstract class BackInTimeDebugServiceTest {
     private lateinit var service: BackInTimeDebugService
-    private val eventSlot = slot<BackInTimeDebugServiceEvent>()
-    private val mutableEvents = mutableListOf<BackInTimeDebugServiceEvent>()
-    val events: List<BackInTimeDebugServiceEvent> get() = mutableEvents
+    private val eventSlot = slot<DebuggableStateHolderEvent>()
+    private val mutableEvents = mutableListOf<DebuggableStateHolderEvent>()
+    val events: List<DebuggableStateHolderEvent> get() = mutableEvents
 
-    val registerInstanceEvents get() = events.filterIsInstance<BackInTimeDebugServiceEvent.RegisterInstance>()
-    val propertyValueChangeEvents get() = events.filterIsInstance<BackInTimeDebugServiceEvent.PropertyValueChange>()
-    val methodCallEvents get() = events.filterIsInstance<BackInTimeDebugServiceEvent.MethodCall>()
-    val registerRelationShipEvents get() = events.filterIsInstance<BackInTimeDebugServiceEvent.RegisterRelationShip>()
+    val registerInstanceEvents get() = events.filterIsInstance<DebuggableStateHolderEvent.RegisterInstance>()
+    val propertyValueChangeEvents get() = events.filterIsInstance<DebuggableStateHolderEvent.PropertyValueChange>()
+    val methodCallEvents get() = events.filterIsInstance<DebuggableStateHolderEvent.MethodCall>()
+    val registerRelationShipEvents get() = events.filterIsInstance<DebuggableStateHolderEvent.RegisterRelationShip>()
 
     @BeforeTest
     fun setup() {

--- a/test/src/jvmTest/kotlin/com/github/kitakkun/backintime/test/base/BackInTimeDebugServiceTest.kt
+++ b/test/src/jvmTest/kotlin/com/github/kitakkun/backintime/test/base/BackInTimeDebugServiceTest.kt
@@ -1,7 +1,7 @@
 package com.github.kitakkun.backintime.test.base
 
 import com.github.kitakkun.backintime.runtime.BackInTimeDebugService
-import com.github.kitakkun.backintime.runtime.BackInTimeDebugServiceEvent
+import com.github.kitakkun.backintime.runtime.DebuggableStateHolderEvent
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.slot
@@ -11,14 +11,14 @@ import kotlin.test.BeforeTest
 
 abstract class BackInTimeDebugServiceTest {
     private lateinit var service: BackInTimeDebugService
-    private val eventSlot = slot<BackInTimeDebugServiceEvent>()
-    private val mutableEvents = mutableListOf<BackInTimeDebugServiceEvent>()
-    val events: List<BackInTimeDebugServiceEvent> get() = mutableEvents
+    private val eventSlot = slot<DebuggableStateHolderEvent>()
+    private val mutableEvents = mutableListOf<DebuggableStateHolderEvent>()
+    val events: List<DebuggableStateHolderEvent> get() = mutableEvents
 
-    val registerInstanceEvents get() = events.filterIsInstance<BackInTimeDebugServiceEvent.RegisterInstance>()
-    val propertyValueChangeEvents get() = events.filterIsInstance<BackInTimeDebugServiceEvent.PropertyValueChange>()
-    val methodCallEvents get() = events.filterIsInstance<BackInTimeDebugServiceEvent.MethodCall>()
-    val registerRelationShipEvents get() = events.filterIsInstance<BackInTimeDebugServiceEvent.RegisterRelationShip>()
+    val registerInstanceEvents get() = events.filterIsInstance<DebuggableStateHolderEvent.RegisterInstance>()
+    val propertyValueChangeEvents get() = events.filterIsInstance<DebuggableStateHolderEvent.PropertyValueChange>()
+    val methodCallEvents get() = events.filterIsInstance<DebuggableStateHolderEvent.MethodCall>()
+    val registerRelationShipEvents get() = events.filterIsInstance<DebuggableStateHolderEvent.RegisterRelationShip>()
 
     @BeforeTest
     fun setup() {


### PR DESCRIPTION
## Renaming Events
- rename `BackInTimeDebugService` -> `DebuggableStateHolderEvent`
- rename `FlipperOutgoingEvent` -> `BackInTimeDebugServiceEvent`
- rename `FlipperIncomingEvent` -> `BackInTimeDebuggerEvent`

## Internal Logic Changes

- `BackInTImeDebugServiceEvent` is now emitted through a single path (`serviceEventFlow`).
- events emitted from `DebuggableStateHolder` are now immediately processed and `BackInTimeDebugService` holds their results in its queue until `start()` is called.