### PR TITLE
Add ui module to encapsulate material3

### DIFF
--- a/backintime-debugger/ui/build.gradle.kts
+++ b/backintime-debugger/ui/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.jetbrainsCompose)
+    alias(libs.plugins.backintimeLint)
+}
+
+kotlin {
+    jvm()
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(compose.material3)
+        }
+    }
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/BackInTimeDebuggerTheme.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/BackInTimeDebuggerTheme.kt
@@ -1,0 +1,32 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Shapes
+import androidx.compose.material3.Typography
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+
+@Composable
+fun BackInTimeDebuggerTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        content = content,
+        typography = BackInTimeDebuggerTheme.typography,
+        colorScheme = BackInTimeDebuggerTheme.colorScheme,
+        shapes = BackInTimeDebuggerTheme.shapes,
+    )
+}
+
+object BackInTimeDebuggerTheme {
+    val colorScheme: ColorScheme
+        @Composable
+        @ReadOnlyComposable
+        get() = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme()
+
+    val typography: Typography = Typography()
+
+    val shapes: Shapes = Shapes()
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/Badge.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/Badge.kt
@@ -1,0 +1,23 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.BadgeDefaults
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun Badge(
+    modifier: Modifier = Modifier,
+    containerColor: Color = BadgeDefaults.containerColor,
+    contentColor: Color = contentColorFor(containerColor),
+    content: @Composable (RowScope.() -> Unit)? = null,
+) {
+    androidx.compose.material3.Badge(
+        modifier = modifier,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        content = content,
+    )
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/Button.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/Button.kt
@@ -1,0 +1,40 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ButtonElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+
+@Composable
+fun Button(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    shape: Shape = ButtonDefaults.shape,
+    colors: ButtonColors = ButtonDefaults.buttonColors(),
+    elevation: ButtonElevation? = ButtonDefaults.buttonElevation(),
+    border: BorderStroke? = null,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    content: @Composable RowScope.() -> Unit,
+) {
+    androidx.compose.material3.Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        border = border,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        content = content,
+    )
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/ButtonDefaults.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/ButtonDefaults.kt
@@ -1,0 +1,3 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+val ButtonDefaults = androidx.compose.material3.ButtonDefaults

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/CircularProgressIndicator.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/CircularProgressIndicator.kt
@@ -1,0 +1,25 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.material3.ProgressIndicatorDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.unit.Dp
+
+@Composable
+fun CircularProgressIndicator(
+    modifier: Modifier = Modifier,
+    color: Color = ProgressIndicatorDefaults.circularColor,
+    strokeWidth: Dp = ProgressIndicatorDefaults.CircularStrokeWidth,
+    trackColor: Color = ProgressIndicatorDefaults.circularTrackColor,
+    strokeCap: StrokeCap = ProgressIndicatorDefaults.CircularIndeterminateStrokeCap,
+) {
+    androidx.compose.material3.CircularProgressIndicator(
+        modifier = modifier,
+        color = color,
+        strokeWidth = strokeWidth,
+        trackColor = trackColor,
+        strokeCap = strokeCap,
+    )
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/DropdownMenu.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/DropdownMenu.kt
@@ -1,0 +1,60 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.MenuDefaults
+import androidx.compose.material3.MenuItemColors
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.window.PopupProperties
+
+@Composable
+fun DropdownMenu(
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    offset: DpOffset = DpOffset.Zero,
+    scrollState: ScrollState = rememberScrollState(),
+    properties: PopupProperties = PopupProperties(),
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    androidx.compose.material3.DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        offset = offset,
+        scrollState = scrollState,
+        properties = properties,
+        content = content,
+    )
+}
+
+@Composable
+fun DropdownMenuItem(
+    text: @Composable () -> Unit,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    enabled: Boolean = true,
+    colors: MenuItemColors = MenuDefaults.itemColors(),
+    contentPadding: PaddingValues = PaddingValues(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    androidx.compose.material3.DropdownMenuItem(
+        text = text,
+        onClick = onClick,
+        modifier = modifier,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        enabled = enabled,
+        colors = colors,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+    )
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/HorizontalDivider.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/HorizontalDivider.kt
@@ -1,0 +1,20 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.material3.DividerDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+
+@Composable
+fun HorizontalDivider(
+    modifier: Modifier = Modifier,
+    thickness: Dp = DividerDefaults.Thickness,
+    color: Color = DividerDefaults.color,
+) {
+    androidx.compose.material3.HorizontalDivider(
+        modifier = modifier,
+        thickness = thickness,
+        color = color,
+    )
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/Icon.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/Icon.kt
@@ -1,0 +1,54 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
+
+@Composable
+fun Icon(
+    imageVector: ImageVector,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: Color = LocalContentColor.current,
+) {
+    androidx.compose.material3.Icon(
+        imageVector = imageVector,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        tint = tint,
+    )
+}
+
+@Composable
+fun Icon(
+    painter: Painter,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: Color = LocalContentColor.current,
+) {
+    androidx.compose.material3.Icon(
+        painter = painter,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        tint = tint,
+    )
+}
+
+@Composable
+fun Icon(
+    bitmap: ImageBitmap,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: Color = LocalContentColor.current,
+) {
+    androidx.compose.material3.Icon(
+        bitmap = bitmap,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        tint = tint,
+    )
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/IconButton.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/IconButton.kt
@@ -1,0 +1,27 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.IconButtonColors
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+
+@Composable
+fun IconButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    colors: IconButtonColors = IconButtonDefaults.iconButtonColors(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    content: @Composable () -> Unit,
+) {
+    androidx.compose.material3.IconButton(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        colors = colors,
+        interactionSource = interactionSource,
+        content = content,
+    )
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/OutlinedTextField.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/OutlinedTextField.kt
@@ -1,0 +1,121 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
+
+@Composable
+fun OutlinedTextField(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = LocalTextStyle.current,
+    label: @Composable (() -> Unit)? = null,
+    placeholder: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    prefix: @Composable (() -> Unit)? = null,
+    suffix: @Composable (() -> Unit)? = null,
+    supportingText: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    shape: Shape = OutlinedTextFieldDefaults.shape,
+    colors: TextFieldColors = OutlinedTextFieldDefaults.colors(),
+) {
+    androidx.compose.material3.OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        enabled = enabled,
+        readOnly = readOnly,
+        textStyle = textStyle,
+        label = label,
+        placeholder = placeholder,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        prefix = prefix,
+        suffix = suffix,
+        supportingText = supportingText,
+        isError = isError,
+        visualTransformation = visualTransformation,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        singleLine = singleLine,
+        maxLines = maxLines,
+        minLines = minLines,
+        interactionSource = interactionSource,
+        shape = shape,
+        colors = colors,
+    )
+}
+
+@Composable
+fun OutlinedTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = LocalTextStyle.current,
+    label: @Composable (() -> Unit)? = null,
+    placeholder: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    prefix: @Composable (() -> Unit)? = null,
+    suffix: @Composable (() -> Unit)? = null,
+    supportingText: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    shape: Shape = OutlinedTextFieldDefaults.shape,
+    colors: TextFieldColors = OutlinedTextFieldDefaults.colors(),
+) {
+    androidx.compose.material3.OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        enabled = enabled,
+        readOnly = readOnly,
+        textStyle = textStyle,
+        label = label,
+        placeholder = placeholder,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        prefix = prefix,
+        suffix = suffix,
+        supportingText = supportingText,
+        isError = isError,
+        visualTransformation = visualTransformation,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        singleLine = singleLine,
+        maxLines = maxLines,
+        minLines = minLines,
+        interactionSource = interactionSource,
+        shape = shape,
+        colors = colors,
+    )
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/Scaffold.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/Scaffold.kt
@@ -1,0 +1,38 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.FabPosition
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ScaffoldDefaults
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun Scaffold(
+    modifier: Modifier = Modifier,
+    topBar: @Composable () -> Unit = {},
+    bottomBar: @Composable () -> Unit = {},
+    snackbarHost: @Composable () -> Unit = {},
+    floatingActionButton: @Composable () -> Unit = {},
+    floatingActionButtonPosition: FabPosition = FabPosition.End,
+    containerColor: Color = MaterialTheme.colorScheme.background,
+    contentColor: Color = contentColorFor(containerColor),
+    contentWindowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    androidx.compose.material3.Scaffold(
+        modifier = modifier,
+        topBar = topBar,
+        bottomBar = bottomBar,
+        snackbarHost = snackbarHost,
+        floatingActionButton = floatingActionButton,
+        floatingActionButtonPosition = floatingActionButtonPosition,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        contentWindowInsets = contentWindowInsets,
+        content = content,
+    )
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/Snackbar.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/Snackbar.kt
@@ -1,0 +1,33 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.material3.SnackbarData
+import androidx.compose.material3.SnackbarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+
+@Composable
+fun Snackbar(
+    snackbarData: SnackbarData,
+    modifier: Modifier = Modifier,
+    actionOnNewLine: Boolean = false,
+    shape: Shape = SnackbarDefaults.shape,
+    containerColor: Color = SnackbarDefaults.color,
+    contentColor: Color = SnackbarDefaults.contentColor,
+    actionColor: Color = SnackbarDefaults.actionColor,
+    actionContentColor: Color = SnackbarDefaults.actionContentColor,
+    dismissActionContentColor: Color = SnackbarDefaults.dismissActionContentColor,
+) {
+    androidx.compose.material3.Snackbar(
+        snackbarData = snackbarData,
+        modifier = modifier,
+        actionOnNewLine = actionOnNewLine,
+        shape = shape,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        actionColor = actionColor,
+        actionContentColor = actionContentColor,
+        dismissActionContentColor = dismissActionContentColor,
+    )
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/SnackbarHost.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/SnackbarHost.kt
@@ -1,0 +1,19 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.material3.SnackbarData
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SnackbarHost(
+    hostState: SnackbarHostState,
+    modifier: Modifier = Modifier,
+    snackbar: @Composable (SnackbarData) -> Unit = { androidx.compose.material3.Snackbar(it) },
+) {
+    androidx.compose.material3.SnackbarHost(
+        hostState = hostState,
+        modifier = modifier,
+        snackbar = snackbar,
+    )
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/Switch.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/Switch.kt
@@ -1,0 +1,29 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.SwitchColors
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+
+@Composable
+fun Switch(
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)?,
+    modifier: Modifier = Modifier,
+    thumbContent: (@Composable () -> Unit)? = null,
+    enabled: Boolean = true,
+    colors: SwitchColors = SwitchDefaults.colors(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    androidx.compose.material3.Switch(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        modifier = modifier,
+        thumbContent = thumbContent,
+        enabled = enabled,
+        colors = colors,
+        interactionSource = interactionSource,
+    )
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/Text.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/Text.kt
@@ -1,0 +1,181 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+
+@Composable
+fun Text(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: ((TextLayoutResult) -> Unit)? = null,
+    style: TextStyle = LocalTextStyle.current,
+) {
+    androidx.compose.material3.Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = style,
+    )
+}
+
+@Composable
+fun Text(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    style: TextStyle = LocalTextStyle.current,
+) {
+    androidx.compose.material3.Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        onTextLayout = onTextLayout,
+        style = style,
+    )
+}
+
+@Composable
+fun Text(
+    text: AnnotatedString,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    inlineContent: Map<String, InlineTextContent> = mapOf(),
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    style: TextStyle = LocalTextStyle.current,
+) {
+    androidx.compose.material3.Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        inlineContent = inlineContent,
+        onTextLayout = onTextLayout,
+        style = style,
+    )
+}
+
+@Composable
+fun Text(
+    text: AnnotatedString,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    inlineContent: Map<String, InlineTextContent> = mapOf(),
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    style: TextStyle = LocalTextStyle.current,
+) {
+    androidx.compose.material3.Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        inlineContent = inlineContent,
+        onTextLayout = onTextLayout,
+        style = style,
+    )
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/TextField.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/TextField.kt
@@ -1,0 +1,121 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
+
+@Composable
+fun TextField(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = LocalTextStyle.current,
+    label: @Composable (() -> Unit)? = null,
+    placeholder: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    prefix: @Composable (() -> Unit)? = null,
+    suffix: @Composable (() -> Unit)? = null,
+    supportingText: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    shape: Shape = TextFieldDefaults.shape,
+    colors: TextFieldColors = TextFieldDefaults.colors(),
+) {
+    androidx.compose.material3.TextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        enabled = enabled,
+        readOnly = readOnly,
+        textStyle = textStyle,
+        label = label,
+        placeholder = placeholder,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        prefix = prefix,
+        suffix = suffix,
+        supportingText = supportingText,
+        isError = isError,
+        visualTransformation = visualTransformation,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        singleLine = singleLine,
+        maxLines = maxLines,
+        minLines = minLines,
+        interactionSource = interactionSource,
+        shape = shape,
+        colors = colors,
+    )
+}
+
+@Composable
+fun TextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = LocalTextStyle.current,
+    label: @Composable (() -> Unit)? = null,
+    placeholder: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    prefix: @Composable (() -> Unit)? = null,
+    suffix: @Composable (() -> Unit)? = null,
+    supportingText: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    shape: Shape = TextFieldDefaults.shape,
+    colors: TextFieldColors = TextFieldDefaults.colors(),
+) {
+    androidx.compose.material3.TextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        enabled = enabled,
+        readOnly = readOnly,
+        textStyle = textStyle,
+        label = label,
+        placeholder = placeholder,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        prefix = prefix,
+        suffix = suffix,
+        supportingText = supportingText,
+        isError = isError,
+        visualTransformation = visualTransformation,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        singleLine = singleLine,
+        maxLines = maxLines,
+        minLines = minLines,
+        interactionSource = interactionSource,
+        shape = shape,
+        colors = colors,
+    )
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/TopAppBar.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/TopAppBar.kt
@@ -1,0 +1,32 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TopAppBarColors
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TopAppBar(
+    title: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    navigationIcon: @Composable () -> Unit = {},
+    actions: @Composable RowScope.() -> Unit = {},
+    windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
+    colors: TopAppBarColors = TopAppBarDefaults.topAppBarColors(),
+    scrollBehavior: TopAppBarScrollBehavior? = null,
+) {
+    androidx.compose.material3.TopAppBar(
+        title = title,
+        modifier = modifier,
+        navigationIcon = navigationIcon,
+        actions = actions,
+        windowInsets = windowInsets,
+        colors = colors,
+        scrollBehavior = scrollBehavior,
+    )
+}

--- a/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/VerticalDivider.kt
+++ b/backintime-debugger/ui/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/ui/primitive/VerticalDivider.kt
@@ -1,0 +1,20 @@
+package com.github.kitakkun.backintime.debugger.ui.primitive
+
+import androidx.compose.material3.DividerDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+
+@Composable
+fun VerticalDivider(
+    modifier: Modifier = Modifier,
+    thickness: Dp = DividerDefaults.Thickness,
+    color: Color = DividerDefaults.color,
+) {
+    androidx.compose.material3.VerticalDivider(
+        modifier = modifier,
+        thickness = thickness,
+        color = color,
+    )
+}

--- a/build-logic-for-testing/build.gradle.kts
+++ b/build-logic-for-testing/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.ktlint) apply false
     // convention plugin
     alias(libs.plugins.backintimeLint) apply false
+    alias(libs.plugins.debuggerFeature) apply false
 }
 
 group = "com.github.kitakkun.backintime"

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -8,9 +8,15 @@ gradlePlugin {
             id = "backintime.lint"
             implementationClass = "com.github.kitakkun.backintime.convention.LintConventionPlugin"
         }
+        register("com.github.kitakkun.backintime.conventions.debugger.feature") {
+            id = "backintime.debugger.feature"
+            implementationClass = "com.github.kitakkun.backintime.convention.DebuggerFeatureConventionPlugin"
+        }
     }
 }
 
 dependencies {
     compileOnly(libs.ktlint.gradle)
+    compileOnly(libs.kotlin.gradle.plugin)
+    compileOnly(libs.jetbrains.compose.gradle.plugin)
 }

--- a/build-logic/convention/src/main/kotlin/com/github/kitakkun/backintime/convention/DebuggerFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/github/kitakkun/backintime/convention/DebuggerFeatureConventionPlugin.kt
@@ -1,0 +1,32 @@
+package com.github.kitakkun.backintime.convention
+
+import com.github.kitakkun.backintime.convention.extension.compose
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+class DebuggerFeatureConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("org.jetbrains.compose")
+                apply("org.jetbrains.kotlin.multiplatform")
+            }
+
+            configure<KotlinMultiplatformExtension> {
+                jvm()
+
+                with(sourceSets) {
+                    commonMain.dependencies {
+                        implementation(project(":backintime-debugger:ui"))
+                    }
+                    jvmMain.dependencies {
+                        implementation(compose.desktop.currentOs)
+                        implementation(compose.material3)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/github/kitakkun/backintime/convention/extension/Project.kt
+++ b/build-logic/convention/src/main/kotlin/com/github/kitakkun/backintime/convention/extension/Project.kt
@@ -3,5 +3,8 @@ package com.github.kitakkun.backintime.convention.extension
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.compose.ComposeExtension
 
 val Project.libs get() = this.extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+val Project.compose get() = this.extensions.getByType<ComposeExtension>().dependencies

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.ktlint) apply false
+    alias(libs.plugins.jetbrainsCompose) apply false
     // convention plugin
     alias(libs.plugins.backintimeLint) apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     alias(libs.plugins.jetbrainsCompose) apply false
     // convention plugin
     alias(libs.plugins.backintimeLint) apply false
+    alias(libs.plugins.debuggerFeature) apply false
 }
 
 group = "com.github.kitakkun.backintime"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,9 @@ ktlint = "1.2.1"
 jetbrains-compose = "1.6.0"
 
 [libraries]
+# gradle
+kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+jetbrains-compose-gradle-plugin = { group = "org.jetbrains.compose", name = "compose-gradle-plugin", version.ref = "jetbrains-compose" }
 ktlint-gradle = { group = "org.jlleitschuh.gradle", name = "ktlint-gradle", version.ref = "ktlint-gradle" }
 
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
@@ -77,6 +80,8 @@ koin-compose = { group = "io.insert-koin", name = "koin-androidx-compose" }
 [plugins]
 # convention
 backintimeLint = { id = "backintime.lint", version = "unspecified" }
+debuggerFeature = { id = "backintime.debugger.feature", version = "unspecified" }
+
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }
 
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ soloader = "0.10.5"
 
 ktlint-gradle = "12.1.0"
 ktlint = "1.2.1"
+jetbrains-compose = "1.6.0"
 
 [libraries]
 ktlint-gradle = { group = "org.jlleitschuh.gradle", name = "ktlint-gradle", version.ref = "ktlint-gradle" }
@@ -85,3 +86,4 @@ androidApplication = { id = "com.android.application", version.ref = "android-li
 androidLibrary = { id = "com.android.library", version.ref = "android-library" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "jetbrains-compose" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,7 @@ include(
     ":backintime-demo:app",
     ":backintime-debugger:app",
     ":backintime-debugger:data",
+    ":backintime-debugger:ui",
     ":backintime-debugger:featurecommon",
     ":backintime-debugger:feature:instance",
     ":backintime-debugger:feature:log",


### PR DESCRIPTION
If we use material3 directly, we cannot avoid getting confused because there are multiple options to import.

For example...
- `androidx.compose.material3.Text`
- `androidx.compose.material.Text`

So, we solve this problem by adding a `ui` module that encapsulates material UI components. Not all components are wrapped in this module, so we need to add components when required.
