### PR TITLE
Automatically reconnect after being disconnected from the server

### DIFF
--- a/backintime-library/runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/connector/BackInTimeWebSocketClientConnector.kt
+++ b/backintime-library/runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/connector/BackInTimeWebSocketClientConnector.kt
@@ -27,6 +27,10 @@ class BackInTimeWebSocketClientConnector(host: String, port: Int) : BackInTimeCo
                 delay(3000L)
             }
             mutableIsConnectedFlow.value = true
+            // reconnect after disconnection
+            client.closeReason().await()
+            mutableIsConnectedFlow.value = false
+            connect()
         }
     }
 

--- a/backintime-library/runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/connector/BackInTimeWebSocketClientConnector.kt
+++ b/backintime-library/runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/connector/BackInTimeWebSocketClientConnector.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 
-class BackInTimeWebSocketClientConnector(host: String, port: Int) : BackInTimeConnector {
+class BackInTimeWebSocketClientConnector(host: String, port: Int, private val automaticReconnect: Boolean = true) : BackInTimeConnector {
     private val coroutineScope = CoroutineScope(Dispatchers.IO)
     private val client: BackInTimeWebSocketClient = BackInTimeWebSocketClient(host = host, port = port)
     override val connected: Boolean get() = client.isConnected
@@ -28,9 +28,11 @@ class BackInTimeWebSocketClientConnector(host: String, port: Int) : BackInTimeCo
             }
             mutableIsConnectedFlow.value = true
             // reconnect after disconnection
-            client.closeReason().await()
-            mutableIsConnectedFlow.value = false
-            connect()
+            if (automaticReconnect) {
+                client.closeReason().await()
+                mutableIsConnectedFlow.value = false
+                connect()
+            }
         }
     }
 

--- a/backintime-library/websocket/client/src/commonMain/kotlin/com/github/kitakkun/backintime/websocket/client/BackInTimeWebSocketClient.kt
+++ b/backintime-library/websocket/client/src/commonMain/kotlin/com/github/kitakkun/backintime/websocket/client/BackInTimeWebSocketClient.kt
@@ -41,11 +41,16 @@ class BackInTimeWebSocketClient(
     suspend fun connect(): Result<Unit> {
         return try {
             session = client.webSocketSession(host = host, port = port, path = "/backintime")
+            session?.closeReason?.invokeOnCompletion {
+                session = null
+            }
             Result.success(Unit)
         } catch (e: Throwable) {
             Result.failure(e)
         }
     }
+
+    fun closeReason() = session?.closeReason ?: error("Not connected")
 
     fun receiveEventAsFlow() = session?.incoming?.receiveAsFlow()
         ?.filterIsInstance<Frame.Text>()


### PR DESCRIPTION
Currently, the WebSocket client doesn't reconnect automatically after being disconnected from the server.

This PR fixes this issue by waiting to close a session and calling `connect` again. We can enable the auto-reconnect feature by passing `automaticReconnect` to the `BackInTimeWebSocketClientConnector`.

Note that the default value for `automaticReconnect` is `true`.