### PR TITLE
Implement Settings Tab

### DIFF
--- a/backintime-debugger/app/src/commonMain/composeResources/values/strings.xml
+++ b/backintime-debugger/app/src/commonMain/composeResources/values/strings.xml
@@ -3,4 +3,7 @@
     <string name="starting_websocket_server">Starting WebSocket server...</string>
     <string name="websocket_server_started">WebSocket server started</string>
     <string name="dismiss">Dismiss</string>
+    <string name="server_error">Server Error: %1$s</string>
+    <string name="restart_server">Restart Server</string>
+    <string name="unknown_error">Unknown Error</string>
 </resources>

--- a/backintime-debugger/app/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/root/RootScreenModel.kt
+++ b/backintime-debugger/app/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/root/RootScreenModel.kt
@@ -1,23 +1,20 @@
 package com.github.kitakkun.backintime.debugger.root
 
-import androidx.compose.runtime.State
-import androidx.compose.runtime.mutableStateOf
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.kitakkun.backintime.debugger.data.repository.SettingsRepository
 import com.github.kitakkun.backintime.debugger.data.server.BackInTimeDebuggerService
+import com.github.kitakkun.backintime.debugger.data.server.BackInTimeDebuggerServiceState
+import kotlinx.coroutines.flow.StateFlow
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 class RootScreenModel(
     private val settingsRepository: SettingsRepository,
 ) : ScreenModel, KoinComponent {
-    private val server: BackInTimeDebuggerService by inject()
-
-    private val mutableState = mutableStateOf(RootState())
-    val state: State<RootState> = mutableState
+    private val service: BackInTimeDebuggerService by inject()
+    val serverState: StateFlow<BackInTimeDebuggerServiceState> = service.serviceStateFlow
 
     fun startServer() {
-        server.start(host = "localhost", port = settingsRepository.webSocketPort)
-        mutableState.value = state.value.copy(isServerRunning = true)
+        service.start(host = "localhost", port = settingsRepository.webSocketPort)
     }
 }

--- a/backintime-debugger/app/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/root/RootState.kt
+++ b/backintime-debugger/app/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/root/RootState.kt
@@ -1,5 +1,0 @@
-package com.github.kitakkun.backintime.debugger.root
-
-data class RootState(
-    val isServerRunning: Boolean = false,
-)

--- a/backintime-debugger/app/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/root/RootView.kt
+++ b/backintime-debugger/app/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/root/RootView.kt
@@ -1,32 +1,20 @@
 package com.github.kitakkun.backintime.debugger.root
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.NavigationRail
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.tab.CurrentTab
 import cafe.adriel.voyager.navigator.tab.TabNavigator
-import com.github.kitakkun.backintime.app.generated.resources.Res
-import com.github.kitakkun.backintime.app.generated.resources.starting_websocket_server
 import com.github.kitakkun.backintime.debugger.feature.connection.ConnectionTab
 import com.github.kitakkun.backintime.debugger.feature.instance.InstancesTab
 import com.github.kitakkun.backintime.debugger.feature.log.LogTab
 import com.github.kitakkun.backintime.debugger.feature.settings.SettingsTab
-import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun RootView(
-    state: RootState,
     snackbarHost: @Composable () -> Unit,
 ) {
     Scaffold(
@@ -41,19 +29,7 @@ fun RootView(
                     TabNavigationRailItem(ConnectionTab)
                     TabNavigationRailItem(SettingsTab)
                 }
-                if (!state.isServerRunning) {
-                    Column(
-                        modifier = Modifier.fillMaxSize(),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.Center,
-                    ) {
-                        Text(stringResource(Res.string.starting_websocket_server))
-                        Spacer(modifier = Modifier.height(16.dp))
-                        CircularProgressIndicator()
-                    }
-                } else {
-                    CurrentTab()
-                }
+                CurrentTab()
             }
         }
     }

--- a/backintime-debugger/app/src/jvmMain/kotlin/com/github/kitakkun/backintime/debugger/Main.kt
+++ b/backintime-debugger/app/src/jvmMain/kotlin/com/github/kitakkun/backintime/debugger/Main.kt
@@ -10,6 +10,7 @@ import com.github.kitakkun.backintime.app.generated.resources.Res
 import com.github.kitakkun.backintime.app.generated.resources.app_name
 import com.github.kitakkun.backintime.debugger.data.di.dataModule
 import com.github.kitakkun.backintime.debugger.feature.connection.connectionFeatureModule
+import com.github.kitakkun.backintime.debugger.feature.settings.settingsFeatureModule
 import org.jetbrains.compose.resources.stringResource
 import org.koin.core.context.startKoin
 
@@ -19,6 +20,7 @@ fun main() {
             appModule,
             dataModule,
             connectionFeatureModule,
+            settingsFeatureModule,
         )
     }
 

--- a/backintime-debugger/data/build.gradle.kts
+++ b/backintime-debugger/data/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
             implementation(libs.sqldelight.coroutines.extensions)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.multiplatform.settings)
+            implementation(libs.multiplatform.settings.coroutines)
             implementation(libs.koin.core)
             implementation(libs.kotlinx.datetime)
         }

--- a/backintime-debugger/data/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/data/repository/SettingsRepository.kt
+++ b/backintime-debugger/data/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/data/repository/SettingsRepository.kt
@@ -1,17 +1,28 @@
 package com.github.kitakkun.backintime.debugger.data.repository
 
-import com.russhwolf.settings.Settings
+import com.github.kitakkun.backintime.debugger.data.settings.createObservableSettings
+import com.russhwolf.settings.ExperimentalSettingsApi
+import com.russhwolf.settings.ObservableSettings
 import com.russhwolf.settings.boolean
+import com.russhwolf.settings.coroutines.getBooleanFlow
+import com.russhwolf.settings.coroutines.getIntFlow
 import com.russhwolf.settings.int
+import kotlinx.coroutines.flow.Flow
 
 interface SettingsRepository {
     var webSocketPort: Int
+    val websocketPortFlow: Flow<Int>
     var deleteSessionDataOnDisconnect: Boolean
+    val deleteSessionDataOnDisconnectFlow: Flow<Boolean>
 }
 
+@OptIn(ExperimentalSettingsApi::class)
 class SettingsRepositoryImpl : SettingsRepository {
-    private val settings: Settings = Settings()
+    private val observableSettings: ObservableSettings = createObservableSettings()
 
-    override var webSocketPort: Int by settings.int("port", 8080)
-    override var deleteSessionDataOnDisconnect: Boolean by settings.boolean("deleteSessionDataOnDisconnect", true)
+    override var webSocketPort: Int by observableSettings.int("port", 8080)
+    override val websocketPortFlow: Flow<Int> = observableSettings.getIntFlow("port", 8080)
+
+    override var deleteSessionDataOnDisconnect: Boolean by observableSettings.boolean("deleteSessionDataOnDisconnect", true)
+    override val deleteSessionDataOnDisconnectFlow: Flow<Boolean> = observableSettings.getBooleanFlow("deleteSessionDataOnDisconnect", true)
 }

--- a/backintime-debugger/data/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/data/server/BackInTimeDebuggerService.kt
+++ b/backintime-debugger/data/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/data/server/BackInTimeDebuggerService.kt
@@ -4,6 +4,8 @@ import com.github.kitakkun.backintime.debugger.data.coroutines.IOScope
 import com.github.kitakkun.backintime.websocket.event.BackInTimeDebuggerEvent
 import com.github.kitakkun.backintime.websocket.server.BackInTimeWebSocketServer
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class BackInTimeDebuggerService(
@@ -11,7 +13,9 @@ class BackInTimeDebuggerService(
     private val incomingEventProcessor: IncomingEventProcessor,
 ) : CoroutineScope by IOScope() {
     val connectionSpecsFlow = server.connectionSpecsFlow
-    val serverSpecFlow = server.serverSpecFlow
+
+    private val mutableServiceStateFlow: MutableStateFlow<BackInTimeDebuggerServiceState> = MutableStateFlow(BackInTimeDebuggerServiceState.Uninitialized)
+    val serviceStateFlow = mutableServiceStateFlow.asStateFlow()
 
     init {
         launch {
@@ -23,7 +27,11 @@ class BackInTimeDebuggerService(
     }
 
     fun start(host: String, port: Int) {
-        server.start(host, port)
+        val result = server.start(host, port)
+        when {
+            result.isSuccess -> mutableServiceStateFlow.value = BackInTimeDebuggerServiceState.Running(host, port)
+            result.isFailure -> mutableServiceStateFlow.value = BackInTimeDebuggerServiceState.Error(result.exceptionOrNull()!!)
+        }
     }
 
     fun sendEvent(sessionId: String, event: BackInTimeDebuggerEvent) {

--- a/backintime-debugger/data/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/data/server/BackInTimeDebuggerServiceState.kt
+++ b/backintime-debugger/data/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/data/server/BackInTimeDebuggerServiceState.kt
@@ -1,0 +1,7 @@
+package com.github.kitakkun.backintime.debugger.data.server
+
+sealed class BackInTimeDebuggerServiceState {
+    data object Uninitialized : BackInTimeDebuggerServiceState()
+    data class Error(val error: Throwable) : BackInTimeDebuggerServiceState()
+    data class Running(val host: String, val port: Int) : BackInTimeDebuggerServiceState()
+}

--- a/backintime-debugger/data/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/data/settings/CreateObservableSettings.kt
+++ b/backintime-debugger/data/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/data/settings/CreateObservableSettings.kt
@@ -1,0 +1,5 @@
+package com.github.kitakkun.backintime.debugger.data.settings
+
+import com.russhwolf.settings.ObservableSettings
+
+expect fun createObservableSettings(): ObservableSettings

--- a/backintime-debugger/data/src/jvmMain/kotlin/com/github/kitakkun/backintime/debugger/data/settings/CreateObservableSettings.jvm.kt
+++ b/backintime-debugger/data/src/jvmMain/kotlin/com/github/kitakkun/backintime/debugger/data/settings/CreateObservableSettings.jvm.kt
@@ -1,0 +1,8 @@
+package com.github.kitakkun.backintime.debugger.data.settings
+
+import com.russhwolf.settings.ObservableSettings
+import com.russhwolf.settings.PreferencesSettings
+
+actual fun createObservableSettings(): ObservableSettings {
+    return PreferencesSettings.Factory().create()
+}

--- a/backintime-debugger/feature/connection/src/commonMain/composeResources/values/strings.xml
+++ b/backintime-debugger/feature/connection/src/commonMain/composeResources/values/strings.xml
@@ -7,4 +7,5 @@
     <string name="waiting_for_connection">Waiting for connection...</string>
     <string name="active_sessions">Active Sessions</string>
     <string name="text_loading_server_status">Loading Server Status...</string>
+    <string name="failed_to_start_server">Failed to start server. Check your configurations are valid.</string>
 </resources>

--- a/backintime-debugger/feature/connection/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/connection/ConnectionTabBindModel.kt
+++ b/backintime-debugger/feature/connection/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/connection/ConnectionTabBindModel.kt
@@ -8,4 +8,6 @@ sealed interface ConnectionTabBindModel {
         val port: Int,
         val sessionBindModels: List<SessionBindModel>,
     ) : ConnectionTabBindModel
+
+    data class ServerError(private val error: Throwable) : ConnectionTabBindModel
 }

--- a/backintime-debugger/feature/connection/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/connection/ConnectionTabView.kt
+++ b/backintime-debugger/feature/connection/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/connection/ConnectionTabView.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.dp
 import com.github.kitakkun.backintime.connection.generated.resources.Res
 import com.github.kitakkun.backintime.connection.generated.resources.active_sessions
+import com.github.kitakkun.backintime.connection.generated.resources.failed_to_start_server
 import com.github.kitakkun.backintime.connection.generated.resources.host
 import com.github.kitakkun.backintime.connection.generated.resources.ic_server_line
 import com.github.kitakkun.backintime.connection.generated.resources.port
@@ -43,6 +44,7 @@ fun ConnectionTabView(
             is ConnectionTabBindModel.Loading -> LoadingView()
             is ConnectionTabBindModel.ServerNotStarted -> ServerNotStartedView()
             is ConnectionTabBindModel.ServerRunning -> ServerRunningView(it)
+            is ConnectionTabBindModel.ServerError -> ServerErrorView()
         }
     }
 }
@@ -132,6 +134,33 @@ private fun ServerRunningView(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun ServerErrorView() {
+    val errorColor = BackInTimeDebuggerTheme.colorScheme.error
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            painter = painterResource(Res.drawable.ic_server_line),
+            contentDescription = null,
+            modifier = Modifier
+                .size(64.dp)
+                .drawWithContent {
+                    drawContent()
+                    drawLine(
+                        color = errorColor,
+                        start = Offset.Zero,
+                        end = Offset(size.width, size.height),
+                        strokeWidth = 4.dp.toPx(),
+                    )
+                }
+        )
+        Text(stringResource(Res.string.failed_to_start_server))
     }
 }
 

--- a/backintime-debugger/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/backintime-debugger/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="settings_tab_title">Settings</string>
+    <string name="text_loading_settings">Loading Settings...</string>
 </resources>

--- a/backintime-debugger/feature/settings/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/settings/SettingsFeatureModule.kt
+++ b/backintime-debugger/feature/settings/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/settings/SettingsFeatureModule.kt
@@ -1,0 +1,8 @@
+package com.github.kitakkun.backintime.debugger.feature.settings
+
+import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.module
+
+val settingsFeatureModule = module {
+    factoryOf(::SettingsTabScreenModel)
+}

--- a/backintime-debugger/feature/settings/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/settings/SettingsTab.kt
+++ b/backintime-debugger/feature/settings/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/settings/SettingsTab.kt
@@ -3,8 +3,11 @@ package com.github.kitakkun.backintime.debugger.feature.settings
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import cafe.adriel.voyager.koin.getScreenModel
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabOptions
 import com.github.kitakkun.backintime.settings.generated.resources.Res
@@ -27,6 +30,13 @@ object SettingsTab : Tab {
 
     @Composable
     override fun Content() {
-        // TODO
+        val screenModel = getScreenModel<SettingsTabScreenModel>()
+        val bindModel by screenModel.bindModel.collectAsState()
+
+        SettingsTabView(
+            bindModel = bindModel,
+            onChangeWebSocketPort = screenModel::updateWebSocketPort,
+            onChangeDeleteSessionDataOnDisconnect = screenModel::updateDeleteSessionDataOnDisconnect,
+        )
     }
 }

--- a/backintime-debugger/feature/settings/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/settings/SettingsTabBindModel.kt
+++ b/backintime-debugger/feature/settings/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/settings/SettingsTabBindModel.kt
@@ -1,0 +1,9 @@
+package com.github.kitakkun.backintime.debugger.feature.settings
+
+sealed interface SettingsTabBindModel {
+    data object Loading : SettingsTabBindModel
+    data class Loaded(
+        val webSocketPort: Int,
+        val deleteSessionDataOnDisconnect: Boolean,
+    ) : SettingsTabBindModel
+}

--- a/backintime-debugger/feature/settings/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/settings/SettingsTabScreenModel.kt
+++ b/backintime-debugger/feature/settings/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/settings/SettingsTabScreenModel.kt
@@ -1,0 +1,34 @@
+package com.github.kitakkun.backintime.debugger.feature.settings
+
+import cafe.adriel.voyager.core.model.ScreenModel
+import cafe.adriel.voyager.core.model.screenModelScope
+import com.github.kitakkun.backintime.debugger.data.repository.SettingsRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+
+class SettingsTabScreenModel(
+    private val settingsRepository: SettingsRepository
+) : ScreenModel {
+    val bindModel = combine(
+        settingsRepository.websocketPortFlow,
+        settingsRepository.deleteSessionDataOnDisconnectFlow
+    ) { webSocketPort, deleteSessionDataOnDisconnect ->
+        SettingsTabBindModel.Loaded(
+            webSocketPort = webSocketPort,
+            deleteSessionDataOnDisconnect = deleteSessionDataOnDisconnect
+        )
+    }.stateIn(
+        scope = screenModelScope,
+        started = SharingStarted.Lazily,
+        initialValue = SettingsTabBindModel.Loading,
+    )
+
+    fun updateWebSocketPort(webSocketPort: Int) {
+        settingsRepository.webSocketPort = webSocketPort
+    }
+
+    fun updateDeleteSessionDataOnDisconnect(deleteSessionDataOnDisconnect: Boolean) {
+        settingsRepository.deleteSessionDataOnDisconnect = deleteSessionDataOnDisconnect
+    }
+}

--- a/backintime-debugger/feature/settings/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/settings/SettingsTabView.kt
+++ b/backintime-debugger/feature/settings/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/settings/SettingsTabView.kt
@@ -1,0 +1,112 @@
+package com.github.kitakkun.backintime.debugger.feature.settings
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.github.kitakkun.backintime.settings.generated.resources.Res
+import com.github.kitakkun.backintime.settings.generated.resources.settings_tab_title
+import com.github.kitakkun.backintime.settings.generated.resources.text_loading_settings
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun SettingsTabView(
+    bindModel: SettingsTabBindModel,
+    onChangeWebSocketPort: (Int) -> Unit,
+    onChangeDeleteSessionDataOnDisconnect: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (bindModel) {
+        is SettingsTabBindModel.Loading -> LoadingView(modifier = modifier)
+        is SettingsTabBindModel.Loaded -> LoadedView(
+            bindModel = bindModel,
+            onChangeWebSocketPort = onChangeWebSocketPort,
+            onChangeDeleteSessionDataOnDisconnect = onChangeDeleteSessionDataOnDisconnect,
+            modifier = modifier,
+        )
+    }
+
+}
+
+@Composable
+private fun LoadingView(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+    ) {
+        Text(stringResource(Res.string.text_loading_settings))
+        CircularProgressIndicator()
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun LoadedView(
+    bindModel: SettingsTabBindModel.Loaded,
+    onChangeWebSocketPort: (Int) -> Unit,
+    onChangeDeleteSessionDataOnDisconnect: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(stringResource(Res.string.settings_tab_title))
+                }
+            )
+        },
+        modifier = modifier.fillMaxSize(),
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(it)
+                .padding(16.dp)
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            TextFieldSettingItem(
+                label = "WebSocket Port",
+                value = bindModel.webSocketPort.toString(),
+                onValueChange = { onChangeWebSocketPort(it.toIntOrNull() ?: 0) },
+            )
+            SwitchSettingItem(
+                label = "Erase Session Data on Disconnect",
+                checked = bindModel.deleteSessionDataOnDisconnect,
+                onCheckedChange = onChangeDeleteSessionDataOnDisconnect,
+            )
+        }
+    }
+}
+
+
+@Preview
+@Composable
+private fun LoadingViewPreview() {
+    LoadingView()
+}
+
+@Preview
+@Composable
+private fun LoadedViewPreview() {
+    LoadedView(
+        bindModel = SettingsTabBindModel.Loaded(
+            webSocketPort = 8080,
+            deleteSessionDataOnDisconnect = true,
+        ),
+        onChangeWebSocketPort = {},
+        onChangeDeleteSessionDataOnDisconnect = {},
+    )
+}

--- a/backintime-debugger/feature/settings/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/settings/SwitchSettingItem.kt
+++ b/backintime-debugger/feature/settings/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/settings/SwitchSettingItem.kt
@@ -1,0 +1,41 @@
+package com.github.kitakkun.backintime.debugger.feature.settings
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SwitchSettingItem(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(text = label)
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SwitchSettingItemPreview() {
+    SwitchSettingItem(
+        label = "Switch Setting Item",
+        checked = true,
+        onCheckedChange = {},
+    )
+}

--- a/backintime-debugger/feature/settings/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/settings/TextFieldSettingItem.kt
+++ b/backintime-debugger/feature/settings/src/commonMain/kotlin/com/github/kitakkun/backintime/debugger/feature/settings/TextFieldSettingItem.kt
@@ -1,0 +1,70 @@
+package com.github.kitakkun.backintime.debugger.feature.settings
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.github.kitakkun.backintime.debugger.ui.primitive.BackInTimeDebuggerTheme
+
+@Composable
+fun TextFieldSettingItem(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var editable by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(text = label)
+        OutlinedTextField(
+            readOnly = !editable,
+            value = value,
+            onValueChange = onValueChange,
+            trailingIcon = {
+                IconButton(onClick = { editable = !editable }) {
+                    if (editable) {
+                        Icon(
+                            imageVector = Icons.Filled.Done,
+                            contentDescription = "Done",
+                            tint = BackInTimeDebuggerTheme.colorScheme.primary,
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Filled.Edit,
+                            contentDescription = "Edit"
+                        )
+                    }
+                }
+            }
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TextFieldSettingItemPreview() {
+    TextFieldSettingItem(
+        label = "Label",
+        value = "Value",
+        onValueChange = {},
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -94,7 +94,8 @@ koin-core = { group = "io.insert-koin", name = "koin-core", version.ref = "koin"
 koin-test = { group = "io.insert-koin", name = "koin-test", version.ref = "koin" }
 sqldelight-sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 sqldelight-coroutines-extensions = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
-multiplatform-settings = { module = "com.russhwolf:multiplatform-settings-no-arg", version.ref = "multiplatformSettings" }
+multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatformSettings" }
+multiplatform-settings-coroutines = { module = "com.russhwolf:multiplatform-settings-coroutines", version.ref = "multiplatformSettings" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 
 # ktor server


### PR DESCRIPTION
## Screenshot
<img width="1392" alt="image" src="https://github.com/kitakkun/back-in-time-plugin/assets/48154936/641e86ab-762d-49f0-b840-1a4853f9e42d">

## Additional Changes
- `SettingsRepository` now has flows to observe configuration changes.
- To fix the problem we could do nothing after failing to start the server. Now we can reconfigure and restart the server through the snackbar.
- `RootScreen` no longer stays at loading even if the internal server error occurs.
