### PR TITLE
Improve internal IR modification logic

### DIFF
--- a/backintime-library/runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/internal/BackInTimeCompilerInternalApi.kt
+++ b/backintime-library/runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/internal/BackInTimeCompilerInternalApi.kt
@@ -1,0 +1,4 @@
+package com.github.kitakkun.backintime.runtime.internal
+
+@RequiresOptIn(message = "This is an internal API for back-in-time compiler. Do not use it directly.", level = RequiresOptIn.Level.ERROR)
+annotation class BackInTimeCompilerInternalApi

--- a/backintime-library/runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/internal/CaptureUtils.kt
+++ b/backintime-library/runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/internal/CaptureUtils.kt
@@ -1,0 +1,21 @@
+@file:Suppress("UNUSED")
+
+package com.github.kitakkun.backintime.runtime.internal
+
+import com.github.kitakkun.backintime.runtime.BackInTimeDebuggable
+
+@BackInTimeCompilerInternalApi
+internal inline fun <T : Any> captureThenReturnValue(
+    instance: BackInTimeDebuggable,
+    methodInvocationId: String,
+    propertyName: String,
+    propertyValue: T,
+): T {
+    reportPropertyValueChange(
+        instance = instance,
+        methodInvocationId = methodInvocationId,
+        propertyName = propertyName,
+        propertyValue = propertyValue,
+    )
+    return propertyValue
+}

--- a/backintime-library/runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/internal/EventReportUtils.kt
+++ b/backintime-library/runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/internal/EventReportUtils.kt
@@ -1,0 +1,62 @@
+@file:Suppress("UNUSED")
+
+package com.github.kitakkun.backintime.runtime.internal
+
+import com.github.kitakkun.backintime.runtime.BackInTimeDebugService
+import com.github.kitakkun.backintime.runtime.BackInTimeDebuggable
+import com.github.kitakkun.backintime.runtime.event.DebuggableStateHolderEvent
+import com.github.kitakkun.backintime.websocket.event.model.PropertyInfo
+
+@BackInTimeCompilerInternalApi
+internal inline fun reportInstanceRegistration(
+    instance: BackInTimeDebuggable,
+    className: String,
+    superClassName: String,
+    properties: List<PropertyInfo>,
+) = BackInTimeDebugService.emitEvent(
+    DebuggableStateHolderEvent.RegisterInstance(
+        instance = instance,
+        className = className,
+        superClassName = superClassName,
+        properties = properties,
+    ),
+)
+
+@BackInTimeCompilerInternalApi
+internal inline fun reportMethodInvocation(
+    instance: BackInTimeDebuggable,
+    methodInvocationId: String,
+    methodName: String,
+) = BackInTimeDebugService.emitEvent(
+    DebuggableStateHolderEvent.MethodCall(
+        instance = instance,
+        methodCallId = methodInvocationId,
+        methodName = methodName,
+    ),
+)
+
+@BackInTimeCompilerInternalApi
+internal inline fun reportPropertyValueChange(
+    instance: BackInTimeDebuggable,
+    methodInvocationId: String,
+    propertyName: String,
+    propertyValue: Any?,
+) = BackInTimeDebugService.emitEvent(
+    DebuggableStateHolderEvent.PropertyValueChange(
+        instance = instance,
+        methodCallId = methodInvocationId,
+        propertyName = propertyName,
+        propertyValue = propertyValue,
+    ),
+)
+
+@BackInTimeCompilerInternalApi
+internal inline fun reportNewRelationship(
+    parentInstance: BackInTimeDebuggable,
+    childInstance: BackInTimeDebuggable,
+) = BackInTimeDebugService.emitEvent(
+    DebuggableStateHolderEvent.RegisterRelationShip(
+        parentInstance = parentInstance,
+        childInstance = childInstance,
+    ),
+)

--- a/backintime-library/runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/internal/ThrowErrorUtils.kt
+++ b/backintime-library/runtime/src/commonMain/kotlin/com/github/kitakkun/backintime/runtime/internal/ThrowErrorUtils.kt
@@ -1,0 +1,27 @@
+@file:Suppress("UNUSED")
+
+package com.github.kitakkun.backintime.runtime.internal
+
+import com.github.kitakkun.backintime.runtime.exception.BackInTimeRuntimeException
+
+@BackInTimeCompilerInternalApi
+internal inline fun throwTypeMismatchException(
+    propertyName: String,
+    expectedType: String,
+) {
+    throw BackInTimeRuntimeException.TypeMismatchException(
+        propertyName = propertyName,
+        expectedType = expectedType,
+    )
+}
+
+@BackInTimeCompilerInternalApi
+internal inline fun throwNoSuchPropertyException(
+    propertyName: String,
+    parentClassFqName: String,
+) {
+    throw BackInTimeRuntimeException.NoSuchPropertyException(
+        propertyName = propertyName,
+        parentClassFqName = parentClassFqName,
+    )
+}

--- a/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/BackInTimePluginContext.kt
+++ b/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/BackInTimePluginContext.kt
@@ -34,6 +34,9 @@ class BackInTimePluginContext(
     val throwTypeMismatchExceptionFunctionSymbol = referenceFunctions(CallableId(internalCompilerApiPackageFqName, Name.identifier("throwTypeMismatchException"))).first()
     val throwNoSuchPropertyExceptionFunctionSymbol = referenceFunctions(CallableId(internalCompilerApiPackageFqName, Name.identifier("throwNoSuchPropertyException"))).first()
 
+    // capture utils
+    val captureThenReturnValueFunctionSymbol = referenceFunctions(CallableId(internalCompilerApiPackageFqName, Name.identifier("captureThenReturnValue"))).first()
+
     val backInTimeDebuggableInterfaceType = referenceClass(BackInTimeConsts.backInTimeDebuggableInterfaceClassId)!!.defaultType
 
     /**

--- a/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/BackInTimePluginContext.kt
+++ b/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/BackInTimePluginContext.kt
@@ -7,7 +7,6 @@ import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.jvm.ir.isReifiable
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.types.defaultType
-import org.jetbrains.kotlin.ir.util.classId
 import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.ir.util.getSimpleFunction
 import org.jetbrains.kotlin.ir.util.isVararg
@@ -23,17 +22,17 @@ class BackInTimePluginContext(
     val pluginContext: IrPluginContext = baseContext
     val valueContainerClassInfoList: List<ValueContainerClassInfo> = config.valueContainers + UserDefinedValueContainerAnalyzer.analyzeAdditionalValueContainerClassInfo(moduleFragment)
 
-    // BackInTimeDebugService
-    val backInTimeServiceClassSymbol = referenceClass(BackInTimeConsts.backInTimeDebugServiceClassId)!!
+    private val internalCompilerApiPackageFqName = FqName("com.github.kitakkun.backintime.runtime.internal")
 
-    // DebuggableStateHolderEvent
-    private val backInTimeServiceEventClassSymbol = referenceClass(BackInTimeConsts.debuggableStateHolderEventClassId)!!
-    private val backInTimeServiceEventSealedSubClasses = backInTimeServiceEventClassSymbol.owner.sealedSubclasses
-    val emitEventFunctionSymbol = backInTimeServiceClassSymbol.getSimpleFunction("emitEvent")!!
-    val registerInstanceEventConstructorSymbol = backInTimeServiceEventSealedSubClasses.first { it.owner.classId == BackInTimeConsts.registerEventClassId }.constructors.first { it.owner.isPrimary }
-    val registerRelationshipEventConstructorSymbol = backInTimeServiceEventSealedSubClasses.first { it.owner.classId == BackInTimeConsts.registerRelationshipEventClassId }.constructors.first { it.owner.isPrimary }
-    val methodCallEventConstructorSymbol = backInTimeServiceEventSealedSubClasses.first { it.owner.classId == BackInTimeConsts.methodCallEventClassId }.constructors.first { it.owner.isPrimary }
-    val propertyValueChangeEventConstructorSymbol = backInTimeServiceEventSealedSubClasses.first { it.owner.classId == BackInTimeConsts.propertyValueChangeEventClassId }.constructors.first { it.owner.isPrimary }
+    // event report functions
+    val reportInstanceRegistrationFunctionSymbol = referenceFunctions(CallableId(internalCompilerApiPackageFqName, Name.identifier("reportInstanceRegistration"))).first()
+    val reportMethodInvocationFunctionSymbol = referenceFunctions(CallableId(internalCompilerApiPackageFqName, Name.identifier("reportMethodInvocation"))).first()
+    val reportPropertyValueChangeFunctionSymbol = referenceFunctions(CallableId(internalCompilerApiPackageFqName, Name.identifier("reportPropertyValueChange"))).first()
+    val reportNewRelationshipFunctionSymbol = referenceFunctions(CallableId(internalCompilerApiPackageFqName, Name.identifier("reportNewRelationship"))).first()
+
+    // error generation functions
+    val throwTypeMismatchExceptionFunctionSymbol = referenceFunctions(CallableId(internalCompilerApiPackageFqName, Name.identifier("throwTypeMismatchException"))).first()
+    val throwNoSuchPropertyExceptionFunctionSymbol = referenceFunctions(CallableId(internalCompilerApiPackageFqName, Name.identifier("throwNoSuchPropertyException"))).first()
 
     val backInTimeDebuggableInterfaceType = referenceClass(BackInTimeConsts.backInTimeDebuggableInterfaceClassId)!!.defaultType
 
@@ -43,12 +42,6 @@ class BackInTimePluginContext(
     val propertyInfoClass = referenceClass(BackInTimeConsts.propertyInfoClassId)!!
     val propertyInfoClassConstructor = propertyInfoClass.constructors.first { it.owner.isPrimary }
     val listOfFunction = referenceFunctions(BackInTimeConsts.listOfFunctionId).first { it.owner.valueParameters.size == 1 && it.owner.valueParameters.first().isVararg }
-
-    private val backInTimeRuntimeExceptionClassSymbol = referenceClass(BackInTimeConsts.backInTimeRuntimeExceptionClassId)!!
-    val typeMismatchExceptionConstructor = backInTimeRuntimeExceptionClassSymbol.owner.sealedSubclasses
-        .first { it.owner.classId == BackInTimeConsts.typeMismatchExceptionClassId }.constructors.first()
-    val noSuchPropertyExceptionConstructor = backInTimeRuntimeExceptionClassSymbol.owner.sealedSubclasses
-        .first { it.owner.classId == BackInTimeConsts.noSuchPropertyExceptionClassId }.constructors.first()
 
     // kotlinx-serialization
     val backInTimeJsonGetter = referenceProperties(BackInTimeConsts.backInTimeJsonCallableId).single().owner.getter!!

--- a/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/CaptureValueChangeInsideMethodTransformer.kt
+++ b/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/CaptureValueChangeInsideMethodTransformer.kt
@@ -2,8 +2,8 @@ package com.github.kitakkun.backintime.compiler.backend.transformer
 
 import com.github.kitakkun.backintime.compiler.backend.BackInTimePluginContext
 import com.github.kitakkun.backintime.compiler.backend.utils.generateUUIDVariable
-import com.github.kitakkun.backintime.compiler.backend.utils.irBlockBodyBuilder
 import com.github.kitakkun.backintime.compiler.consts.BackInTimeAnnotations
+import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irGet
@@ -28,7 +28,7 @@ class CaptureValueChangeInsideMethodTransformer : IrElementTransformerVoid() {
         val parentClassSymbol = declaration.parentClassOrNull?.symbol ?: return declaration
         val parentClassDispatchReceiver = declaration.dispatchReceiverParameter ?: return declaration
 
-        with(declaration.irBlockBodyBuilder()) {
+        with(irBuiltIns.createIrBuilder(declaration.symbol)) {
             val uuidVariable = generateUUIDVariable() ?: return declaration
 
             val notifyMethodCallFunctionCall = irCall(reportMethodInvocationFunctionSymbol).apply {

--- a/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/CaptureValueChangeInsideMethodTransformer.kt
+++ b/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/CaptureValueChangeInsideMethodTransformer.kt
@@ -3,10 +3,9 @@ package com.github.kitakkun.backintime.compiler.backend.transformer
 import com.github.kitakkun.backintime.compiler.backend.BackInTimePluginContext
 import com.github.kitakkun.backintime.compiler.backend.utils.generateUUIDVariable
 import com.github.kitakkun.backintime.compiler.backend.utils.irBlockBodyBuilder
-import com.github.kitakkun.backintime.compiler.backend.utils.irEmitEventCall
 import com.github.kitakkun.backintime.compiler.consts.BackInTimeAnnotations
 import org.jetbrains.kotlin.ir.IrStatement
-import org.jetbrains.kotlin.ir.builders.irCallConstructor
+import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
@@ -32,12 +31,10 @@ class CaptureValueChangeInsideMethodTransformer : IrElementTransformerVoid() {
         with(declaration.irBlockBodyBuilder()) {
             val uuidVariable = generateUUIDVariable() ?: return declaration
 
-            val notifyMethodCallFunctionCall = irEmitEventCall {
-                irCallConstructor(methodCallEventConstructorSymbol, emptyList()).apply {
-                    putValueArgument(0, irGet(parentClassDispatchReceiver))
-                    putValueArgument(1, irGet(uuidVariable))
-                    putValueArgument(2, irString(declaration.name.asString()))
-                }
+            val notifyMethodCallFunctionCall = irCall(reportMethodInvocationFunctionSymbol).apply {
+                putValueArgument(0, irGet(parentClassDispatchReceiver))
+                putValueArgument(1, irGet(uuidVariable))
+                putValueArgument(2, irString(declaration.name.asString()))
             }
 
             (declaration.body as? IrBlockBody)?.statements?.addAll(0, listOf(uuidVariable, notifyMethodCallFunctionCall))

--- a/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/ConstructorTransformer.kt
+++ b/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/ConstructorTransformer.kt
@@ -5,9 +5,9 @@ import com.github.kitakkun.backintime.compiler.backend.utils.generateUUIDStringC
 import com.github.kitakkun.backintime.compiler.backend.utils.getCompletedName
 import com.github.kitakkun.backintime.compiler.backend.utils.getGenericTypes
 import com.github.kitakkun.backintime.compiler.backend.utils.hasBackInTimeDebuggableAsInterface
-import com.github.kitakkun.backintime.compiler.backend.utils.irBlockBodyBuilder
 import com.github.kitakkun.backintime.compiler.consts.BackInTimeAnnotations
 import com.github.kitakkun.backintime.compiler.consts.BackInTimeConsts
+import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.irBoolean
@@ -46,7 +46,7 @@ class ConstructorTransformer : IrElementTransformerVoid() {
         val parentClass = declaration.parentClassOrNull ?: return declaration
         if (!parentClass.hasBackInTimeDebuggableAsInterface) return declaration
 
-        with(declaration.irBlockBodyBuilder()) {
+        with(irBuiltIns.createIrBuilder(declaration.symbol)) {
             val initUUIDCall = irSetField(
                 receiver = irGet(parentClass.thisReceiver!!),
                 field = parentClass.properties.first { it.name == BackInTimeConsts.backInTimeInstanceUUIDName }.backingField!!,

--- a/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/ConstructorTransformer.kt
+++ b/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/ConstructorTransformer.kt
@@ -6,7 +6,6 @@ import com.github.kitakkun.backintime.compiler.backend.utils.getCompletedName
 import com.github.kitakkun.backintime.compiler.backend.utils.getGenericTypes
 import com.github.kitakkun.backintime.compiler.backend.utils.hasBackInTimeDebuggableAsInterface
 import com.github.kitakkun.backintime.compiler.backend.utils.irBlockBodyBuilder
-import com.github.kitakkun.backintime.compiler.backend.utils.irEmitEventCall
 import com.github.kitakkun.backintime.compiler.consts.BackInTimeAnnotations
 import com.github.kitakkun.backintime.compiler.consts.BackInTimeConsts
 import org.jetbrains.kotlin.ir.IrStatement
@@ -77,13 +76,11 @@ class ConstructorTransformer : IrElementTransformerVoid() {
 
     /** see [com.github.kitakkun.backintime.runtime.event.DebuggableStateHolderEvent.RegisterInstance] */
     @OptIn(UnsafeDuringIrConstructionAPI::class)
-    private fun IrBuilderWithScope.generateRegisterCall(parentClass: IrClass) = irEmitEventCall {
-        irCallConstructor(registerInstanceEventConstructorSymbol, emptyList()).apply {
-            putValueArgument(0, irGet(parentClass.thisReceiver!!))
-            putValueArgument(1, irString(parentClass.fqNameWhenAvailable?.asString() ?: "unknown"))
-            putValueArgument(2, irString(parentClass.superClass?.fqNameWhenAvailable?.asString() ?: "unknown"))
-            putValueArgument(3, generatePropertiesInfo(parentClass.properties))
-        }
+    private fun IrBuilderWithScope.generateRegisterCall(parentClass: IrClass) = irCall(reportInstanceRegistrationFunctionSymbol).apply {
+        putValueArgument(0, irGet(parentClass.thisReceiver!!))
+        putValueArgument(1, irString(parentClass.fqNameWhenAvailable?.asString() ?: "unknown"))
+        putValueArgument(2, irString(parentClass.superClass?.fqNameWhenAvailable?.asString() ?: "unknown"))
+        putValueArgument(3, generatePropertiesInfo(parentClass.properties))
     }
 
     @OptIn(UnsafeDuringIrConstructionAPI::class)

--- a/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/ImplementBackInTimeDebuggableMethodsTransformer.kt
+++ b/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/ImplementBackInTimeDebuggableMethodsTransformer.kt
@@ -3,8 +3,6 @@ package com.github.kitakkun.backintime.compiler.backend.transformer
 import com.github.kitakkun.backintime.compiler.backend.BackInTimePluginContext
 import com.github.kitakkun.backintime.compiler.backend.utils.irBlockBodyBuilder
 import com.github.kitakkun.backintime.compiler.backend.utils.irPropertySetterCall
-import com.github.kitakkun.backintime.compiler.backend.utils.irThrowNoSuchPropertyException
-import com.github.kitakkun.backintime.compiler.backend.utils.irThrowTypeMismatchException
 import com.github.kitakkun.backintime.compiler.backend.utils.irValueContainerPropertySetterCall
 import com.github.kitakkun.backintime.compiler.backend.utils.irWhenByProperties
 import com.github.kitakkun.backintime.compiler.consts.BackInTimeConsts
@@ -17,6 +15,7 @@ import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irIfThenElse
 import org.jetbrains.kotlin.ir.builders.irIs
 import org.jetbrains.kotlin.ir.builders.irReturn
+import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
@@ -86,10 +85,10 @@ class ImplementBackInTimeDebuggableMethodsTransformer : IrElementTransformerVoid
                         )
                     },
                     elseBranchExpression = {
-                        irThrowNoSuchPropertyException(
-                            parentClassFqName = parentClass.kotlinFqName.asString(),
-                            propertyNameParameter = it,
-                        )
+                        irCall(throwNoSuchPropertyExceptionFunctionSymbol).apply {
+                            putValueArgument(0, irString(parentClass.kotlinFqName.asString()))
+                            putValueArgument(1, irGet(it))
+                        }
                     },
                 )
             }
@@ -112,10 +111,10 @@ class ImplementBackInTimeDebuggableMethodsTransformer : IrElementTransformerVoid
                         generateSerializeCall(type = propertyType, valueParameter = valueParameter)
                     },
                     elseBranchExpression = {
-                        irThrowNoSuchPropertyException(
-                            parentClassFqName = parentClass.kotlinFqName.asString(),
-                            propertyNameParameter = it,
-                        )
+                        irCall(throwNoSuchPropertyExceptionFunctionSymbol).apply {
+                            putValueArgument(0, irString(parentClass.kotlinFqName.asString()))
+                            putValueArgument(1, irGet(it))
+                        }
                     },
                 )
             }
@@ -138,10 +137,10 @@ class ImplementBackInTimeDebuggableMethodsTransformer : IrElementTransformerVoid
                         generateDeserializeCall(valueParameter = valueParameter, type = propertyType)
                     },
                     elseBranchExpression = {
-                        irThrowNoSuchPropertyException(
-                            parentClassFqName = parentClass.kotlinFqName.asString(),
-                            propertyNameParameter = it,
-                        )
+                        irCall(throwNoSuchPropertyExceptionFunctionSymbol).apply {
+                            putValueArgument(0, irString(parentClass.kotlinFqName.asString()))
+                            putValueArgument(1, irGet(it))
+                        }
                     },
                 )
             }
@@ -178,7 +177,10 @@ class ImplementBackInTimeDebuggableMethodsTransformer : IrElementTransformerVoid
                 }
             },
             type = pluginContext.irBuiltIns.unitType,
-            elsePart = irThrowTypeMismatchException(propertyName = property.name.asString(), expectedType = serializerType.classFqName?.asString() ?: "unknown"),
+            elsePart = irCall(throwTypeMismatchExceptionFunctionSymbol).apply {
+                putValueArgument(0, irString(property.name.asString()))
+                putValueArgument(1, irString(serializerType.classFqName?.asString() ?: "unknown"))
+            }
         )
     }
 

--- a/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/ImplementBackInTimeDebuggableMethodsTransformer.kt
+++ b/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/ImplementBackInTimeDebuggableMethodsTransformer.kt
@@ -1,11 +1,11 @@
 package com.github.kitakkun.backintime.compiler.backend.transformer
 
 import com.github.kitakkun.backintime.compiler.backend.BackInTimePluginContext
-import com.github.kitakkun.backintime.compiler.backend.utils.irBlockBodyBuilder
 import com.github.kitakkun.backintime.compiler.backend.utils.irPropertySetterCall
 import com.github.kitakkun.backintime.compiler.backend.utils.irValueContainerPropertySetterCall
 import com.github.kitakkun.backintime.compiler.backend.utils.irWhenByProperties
 import com.github.kitakkun.backintime.compiler.consts.BackInTimeConsts
+import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.irBlockBody
@@ -72,7 +72,7 @@ class ImplementBackInTimeDebuggableMethodsTransformer : IrElementTransformerVoid
         val parentClassReceiver = declaration.dispatchReceiverParameter!!
         val (propertyNameParameter, valueParameter) = declaration.valueParameters
 
-        with(declaration.irBlockBodyBuilder()) {
+        with(irBuiltIns.createIrBuilder(declaration.symbol)) {
             return irBlockBody {
                 +irWhenByProperties(
                     properties = parentClass.properties.toList(),
@@ -101,7 +101,7 @@ class ImplementBackInTimeDebuggableMethodsTransformer : IrElementTransformerVoid
     @OptIn(UnsafeDuringIrConstructionAPI::class)
     private fun generateSerializePropertyMethodBody(declaration: IrSimpleFunction, parentClass: IrClass): IrBody {
         val (propertyNameParameter, valueParameter) = declaration.valueParameters
-        with(declaration.irBlockBodyBuilder()) {
+        with(irBuiltIns.createIrBuilder(declaration.symbol)) {
             return irBlockBody {
                 +irWhenByProperties(
                     properties = parentClass.properties.toList(),
@@ -127,7 +127,7 @@ class ImplementBackInTimeDebuggableMethodsTransformer : IrElementTransformerVoid
     @OptIn(UnsafeDuringIrConstructionAPI::class)
     private fun generateDeserializePropertyMethodBody(declaration: IrSimpleFunction, parentClass: IrClass): IrBody {
         val (propertyNameParameter, valueParameter) = declaration.valueParameters
-        with(declaration.irBlockBodyBuilder()) {
+        with(irBuiltIns.createIrBuilder(declaration.symbol)) {
             return irBlockBody {
                 +irWhenByProperties(
                     properties = parentClass.properties.toList(),
@@ -180,7 +180,7 @@ class ImplementBackInTimeDebuggableMethodsTransformer : IrElementTransformerVoid
             elsePart = irCall(throwTypeMismatchExceptionFunctionSymbol).apply {
                 putValueArgument(0, irString(property.name.asString()))
                 putValueArgument(1, irString(serializerType.classFqName?.asString() ?: "unknown"))
-            }
+            },
         )
     }
 

--- a/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/LambdaArgumentBodyTransformer.kt
+++ b/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/LambdaArgumentBodyTransformer.kt
@@ -2,11 +2,10 @@ package com.github.kitakkun.backintime.compiler.backend.transformer
 
 import com.github.kitakkun.backintime.compiler.backend.BackInTimePluginContext
 import com.github.kitakkun.backintime.compiler.backend.utils.generateCaptureValueCallForValueContainer
-import com.github.kitakkun.backintime.compiler.backend.utils.irBlockBodyBuilder
 import com.github.kitakkun.backintime.compiler.backend.utils.receiver
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
+import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.ir.IrElement
-import org.jetbrains.kotlin.ir.builders.Scope
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irComposite
 import org.jetbrains.kotlin.ir.builders.irEquals
@@ -27,7 +26,6 @@ class LambdaArgumentBodyTransformer(
     private val passedProperties: Set<IrProperty>,
     private val classDispatchReceiverParameter: IrValueParameter,
     private val uuidVariable: IrVariable,
-    private val scope: Scope,
 ) : IrElementTransformerVoidWithContext() {
     override fun visitElement(element: IrElement): IrElement {
         element.transformChildrenVoid(this)
@@ -48,7 +46,7 @@ class LambdaArgumentBodyTransformer(
             propertyClassId == receiverClassId
         }
 
-        with(expression.irBlockBodyBuilder(scope)) {
+        with(irBuiltIns.createIrBuilder(expression.symbol)) {
             val captureCalls = possibleReceiverProperties.mapNotNull { property ->
                 val propertyGetter = property.getter ?: return@mapNotNull null
                 val captureCall = property.generateCaptureValueCallForValueContainer(

--- a/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/RelationshipResolveCallGenerationTransformer.kt
+++ b/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/RelationshipResolveCallGenerationTransformer.kt
@@ -2,7 +2,6 @@ package com.github.kitakkun.backintime.compiler.backend.transformer
 
 import com.github.kitakkun.backintime.compiler.backend.BackInTimePluginContext
 import com.github.kitakkun.backintime.compiler.backend.utils.irBlockBodyBuilder
-import com.github.kitakkun.backintime.compiler.backend.utils.irRegisterRelationship
 import com.github.kitakkun.backintime.compiler.backend.utils.receiver
 import com.github.kitakkun.backintime.compiler.consts.BackInTimeAnnotations
 import com.github.kitakkun.backintime.compiler.consts.BackInTimeConsts
@@ -62,10 +61,10 @@ class RelationshipResolveCallGenerationTransformer(
                 val parentReceiver = parentClass.thisReceiver ?: return@mapNotNull null
 
                 with(declaration.irBlockBodyBuilder()) {
-                    irRegisterRelationship(
-                        irGet(parentReceiver),
-                        irGetField(receiver = irGet(parentReceiver), field = backingField),
-                    )
+                    irCall(reportNewRelationshipFunctionSymbol).apply {
+                        putValueArgument(0, irGet(parentReceiver))
+                        putValueArgument(1, irGetField(receiver = irGet(parentReceiver), field = backingField))
+                    }
                 }
             }
         (declaration.body as? IrBlockBody)?.statements?.addAll(propertyRelationshipResolveCalls)
@@ -94,10 +93,10 @@ class RelationshipResolveCallGenerationTransformer(
                     },
                 )
                 val thenPart = irComposite {
-                    +irRegisterRelationship(
-                        receiver,
-                        irCall(property.getter!!).apply { dispatchReceiver = receiver },
-                    )
+                    +irCall(reportNewRelationshipFunctionSymbol).apply {
+                        putValueArgument(0, receiver)
+                        putValueArgument(1, irCall(property.getter!!).apply { dispatchReceiver = receiver })
+                    }
                     +irCall(irBuiltIns.mutableMapClass.getSimpleFunction("put")!!).apply {
                         dispatchReceiver = irGetField(receiver, initializedMapProperty.backingField!!)
                         putValueArgument(0, irString(property.name.asString()))

--- a/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/utils/BackInTimeIrGenerateUtils.kt
+++ b/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/utils/BackInTimeIrGenerateUtils.kt
@@ -2,19 +2,15 @@ package com.github.kitakkun.backintime.compiler.backend.utils
 
 import com.github.kitakkun.backintime.compiler.backend.BackInTimePluginContext
 import com.github.kitakkun.backintime.compiler.consts.BackInTimeConsts
-import org.jetbrains.kotlin.backend.common.lower.irThrow
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.irCall
-import org.jetbrains.kotlin.ir.builders.irCallConstructor
 import org.jetbrains.kotlin.ir.builders.irGet
-import org.jetbrains.kotlin.ir.builders.irGetObject
 import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.expressions.IrCall
-import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.types.classOrNull
@@ -22,35 +18,16 @@ import org.jetbrains.kotlin.ir.util.classId
 import org.jetbrains.kotlin.name.SpecialNames
 
 context(IrBuilderWithScope, BackInTimePluginContext)
-fun irEmitEventCall(configureEvent: () -> IrExpression): IrCall {
-    return irCall(emitEventFunctionSymbol).apply {
-        dispatchReceiver = irGetObject(backInTimeServiceClassSymbol)
-        putValueArgument(0, configureEvent())
-    }
-}
-
-context(BackInTimePluginContext, IrBuilderWithScope)
-fun irRegisterRelationship(getParentInstance: IrExpression, getChildInstance: IrExpression) =
-    irEmitEventCall {
-        irCallConstructor(registerRelationshipEventConstructorSymbol, emptyList()).apply {
-            putValueArgument(0, getParentInstance)
-            putValueArgument(1, getChildInstance)
-        }
-    }
-
-context(IrBuilderWithScope, BackInTimePluginContext)
 fun irCapturePropertyValue(
     propertyName: String,
     getValueCall: IrCall,
     instanceParameter: IrValueParameter,
     uuidVariable: IrVariable,
-) = irEmitEventCall {
-    irCallConstructor(propertyValueChangeEventConstructorSymbol, emptyList()).apply {
-        putValueArgument(0, irGet(instanceParameter))
-        putValueArgument(1, irGet(uuidVariable))
-        putValueArgument(2, irString(propertyName))
-        putValueArgument(3, getValueCall)
-    }
+) = irCall(reportPropertyValueChangeFunctionSymbol).apply {
+    putValueArgument(0, irGet(instanceParameter))
+    putValueArgument(1, irGet(uuidVariable))
+    putValueArgument(2, irString(propertyName))
+    putValueArgument(3, getValueCall)
 }
 
 context(IrBuilderWithScope, BackInTimePluginContext)
@@ -109,25 +86,3 @@ private fun IrProperty.getValueHolderValueGetterSymbol(): IrSimpleFunctionSymbol
 context(BackInTimePluginContext)
 val IrClass.hasBackInTimeDebuggableAsInterface
     get() = superTypes.any { it.classFqName == BackInTimeConsts.backInTimeDebuggableInterfaceClassFqName }
-
-context(BackInTimePluginContext)
-fun IrBuilderWithScope.irThrowTypeMismatchException(
-    expectedType: String,
-    propertyName: String,
-) = irThrow(
-    irCallConstructor(typeMismatchExceptionConstructor, emptyList()).apply {
-        putValueArgument(0, irString(propertyName))
-        putValueArgument(1, irString(expectedType))
-    },
-)
-
-context(BackInTimePluginContext)
-fun IrBuilderWithScope.irThrowNoSuchPropertyException(
-    parentClassFqName: String,
-    propertyNameParameter: IrValueParameter,
-) = irThrow(
-    irCallConstructor(noSuchPropertyExceptionConstructor, emptyList()).apply {
-        putValueArgument(0, irString(parentClassFqName))
-        putValueArgument(1, irGet(propertyNameParameter))
-    },
-)

--- a/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/utils/BackInTimeIrGenerateUtils.kt
+++ b/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/utils/BackInTimeIrGenerateUtils.kt
@@ -31,22 +31,6 @@ fun irCapturePropertyValue(
 }
 
 context(IrBuilderWithScope, BackInTimePluginContext)
-fun IrProperty.generateCaptureValueCallForPureVariable(
-    instanceParameter: IrValueParameter,
-    uuidVariable: IrVariable,
-): IrCall? {
-    val getter = getter ?: return null
-    return irCapturePropertyValue(
-        propertyName = name.asString(),
-        getValueCall = irCall(getter.symbol).apply {
-            this.dispatchReceiver = irGet(instanceParameter)
-        },
-        instanceParameter = instanceParameter,
-        uuidVariable = uuidVariable,
-    )
-}
-
-context(IrBuilderWithScope, BackInTimePluginContext)
 fun IrProperty.generateCaptureValueCallForValueContainer(
     instanceParameter: IrValueParameter,
     uuidVariable: IrVariable,

--- a/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/utils/BackendUtils.kt
+++ b/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/utils/BackendUtils.kt
@@ -1,29 +1,32 @@
 package com.github.kitakkun.backintime.compiler.backend.utils
 
 import com.github.kitakkun.backintime.compiler.backend.BackInTimePluginContext
-import com.github.kitakkun.backintime.compiler.consts.BackInTimeConsts
-import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
-import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.irCall
-import org.jetbrains.kotlin.ir.builders.irTemporary
+import org.jetbrains.kotlin.ir.builders.parent
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrVariable
+import org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl
 import org.jetbrains.kotlin.ir.expressions.IrCall
-import org.jetbrains.kotlin.ir.util.getSimpleFunction
+import org.jetbrains.kotlin.ir.symbols.impl.IrVariableSymbolImpl
+import org.jetbrains.kotlin.name.Name
 
-context(IrPluginContext)
-fun IrBlockBodyBuilder.generateUUIDVariable(): IrVariable? {
-    val uuidClass = referenceClass(BackInTimeConsts.UUIDClassId) ?: return null
-    val randomUUIDFunction = uuidClass.getSimpleFunction(BackInTimeConsts.RANDOM_UUID_FUNCTION_NAME) ?: return null
-    val toStringFunction = uuidClass.getSimpleFunction("toString") ?: return null
-    return irTemporary(
-        value = irCall(toStringFunction).apply {
-            dispatchReceiver = irCall(randomUUIDFunction)
-        },
-        irType = irBuiltIns.stringType,
+context(BackInTimePluginContext)
+fun IrBuilderWithScope.generateUUIDVariable(): IrVariable? {
+    return IrVariableImpl(
+        startOffset = this.startOffset,
+        endOffset = this.endOffset,
         origin = IrDeclarationOrigin.DEFINED,
-    )
+        symbol = IrVariableSymbolImpl(),
+        name = Name.identifier("backInTimeUUID"),
+        type = irBuiltIns.stringType,
+        isVar = false,
+        isConst = false,
+        isLateinit = false,
+    ).apply {
+        this.initializer = generateUUIDStringCall()
+        this.parent = this@generateUUIDVariable.parent
+    }
 }
 
 context(BackInTimePluginContext)

--- a/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/utils/IrBuilderUtils.kt
+++ b/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/utils/IrBuilderUtils.kt
@@ -1,12 +1,8 @@
 package com.github.kitakkun.backintime.compiler.backend.utils
 
-import com.github.kitakkun.backintime.compiler.backend.BackInTimePluginContext
 import com.github.kitakkun.backintime.compiler.backend.ValueContainerClassInfo
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
-import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
-import org.jetbrains.kotlin.ir.builders.IrBlockBuilder
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
-import org.jetbrains.kotlin.ir.builders.Scope
 import org.jetbrains.kotlin.ir.builders.irBlock
 import org.jetbrains.kotlin.ir.builders.irBranch
 import org.jetbrains.kotlin.ir.builders.irCall
@@ -18,51 +14,10 @@ import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.builders.irWhen
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
-import org.jetbrains.kotlin.ir.declarations.IrSymbolOwner
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrWhen
 import org.jetbrains.kotlin.ir.types.classOrNull
-
-fun IrSymbolOwner.irBlockBuilder(pluginContext: IrPluginContext) = IrBlockBuilder(
-    context = pluginContext,
-    scope = Scope(symbol),
-    startOffset = startOffset,
-    endOffset = endOffset,
-)
-
-fun IrSymbolOwner.irBlockBodyBuilder(pluginContext: IrPluginContext) = IrBlockBodyBuilder(
-    context = pluginContext,
-    scope = Scope(symbol),
-    startOffset = startOffset,
-    endOffset = endOffset,
-)
-
-fun IrExpression.irBlockBuilder(pluginContext: IrPluginContext, scope: Scope) = IrBlockBuilder(
-    context = pluginContext,
-    scope = scope,
-    startOffset = startOffset,
-    endOffset = endOffset,
-)
-
-fun IrExpression.irBlockBodyBuilder(pluginContext: IrPluginContext, scope: Scope) = IrBlockBodyBuilder(
-    context = pluginContext,
-    scope = scope,
-    startOffset = startOffset,
-    endOffset = endOffset,
-)
-
-context(BackInTimePluginContext)
-fun IrSymbolOwner.irBlockBuilder() = irBlockBuilder(pluginContext)
-
-context(BackInTimePluginContext)
-fun IrSymbolOwner.irBlockBodyBuilder() = irBlockBodyBuilder(pluginContext)
-
-context(BackInTimePluginContext)
-fun IrExpression.irBlockBuilder(scope: Scope) = irBlockBuilder(pluginContext, scope)
-
-context(BackInTimePluginContext)
-fun IrExpression.irBlockBodyBuilder(scope: Scope) = irBlockBodyBuilder(pluginContext, scope)
 
 context(IrPluginContext)
 fun IrBuilderWithScope.irPropertySetterCall(


### PR DESCRIPTION
Some IR modification logics are too complicated and thus difficult to maintain.
This PR makes them cleaner and easier to read.

## Changes
- Replace own util functions to build `IrBuilder` with `IrPluginContext.irBuiltIns.createIrBuilder`.
- Remove messy IR instantiation of Events, instead of this, add internal util functions which can be called from compiler-inserted code.
