### PR TITLE
Fix: Resolve Inability to Back-in-Time Debug Private Superclass Properties

### DIFF
--- a/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/implement/BackInTimeDebuggableImplementTransformer.kt
+++ b/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/implement/BackInTimeDebuggableImplementTransformer.kt
@@ -6,6 +6,7 @@ import com.github.kitakkun.backintime.compiler.backend.utils.irValueContainerPro
 import com.github.kitakkun.backintime.compiler.backend.utils.isBackInTimeGenerated
 import com.github.kitakkun.backintime.compiler.consts.BackInTimeConsts
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
+import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.declarations.addBackingField
@@ -36,6 +37,7 @@ import org.jetbrains.kotlin.ir.util.classId
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.util.properties
+import org.jetbrains.kotlin.ir.util.superClass
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 
 context(BackInTimePluginContext)
@@ -79,6 +81,9 @@ class BackInTimeDebuggableImplementTransformer : IrElementTransformerVoid() {
         val parentClassReceiver = declaration.dispatchReceiverParameter!!
         val (propertyNameParameter, valueParameter) = declaration.valueParameters
 
+        val superDeclarationSymbol = declaration.overriddenSymbols.firstOrNull { it.owner.modality == Modality.OPEN }
+        val superClassSymbol = parentClass.superClass?.symbol
+
         return irBuiltIns.createIrBuilder(declaration.symbol).irBlockBody {
             +irWhen(
                 type = irBuiltIns.unitType,
@@ -93,10 +98,21 @@ class BackInTimeDebuggableImplementTransformer : IrElementTransformerVoid() {
                     )
                 }.plus(
                     irElseBranch(
-                        irCall(throwNoSuchPropertyExceptionFunctionSymbol).apply {
-                            putValueArgument(0, irGet(propertyNameParameter))
-                            putValueArgument(1, irString(parentClass.kotlinFqName.asString()))
-                        },
+                        if (superDeclarationSymbol != null && superClassSymbol != null) {
+                            irCall(
+                                callee = superDeclarationSymbol.owner,
+                                superQualifierSymbol = superClassSymbol,
+                            ).apply {
+                                dispatchReceiver = irGet(parentClassReceiver)
+                                putValueArgument(0, irGet(propertyNameParameter))
+                                putValueArgument(1, irGet(valueParameter))
+                            }
+                        } else {
+                            irCall(throwNoSuchPropertyExceptionFunctionSymbol).apply {
+                                putValueArgument(0, irGet(propertyNameParameter))
+                                putValueArgument(1, irString(parentClass.kotlinFqName.asString()))
+                            }
+                        }
                     ),
                 ).toList(),
             )
@@ -110,6 +126,11 @@ class BackInTimeDebuggableImplementTransformer : IrElementTransformerVoid() {
         val parentClass = declaration.parentAsClass
         val (propertyNameParameter, valueParameter) = declaration.valueParameters
         val irBuilder = irBuiltIns.createIrBuilder(declaration.symbol)
+
+        val superDeclarationSymbol = declaration.overriddenSymbols.firstOrNull { it.owner.modality == Modality.OPEN }
+        val superClassSymbol = parentClass.superClass?.symbol
+        val parentClassReceiver = declaration.dispatchReceiverParameter
+
         return with(irBuilder) {
             irExprBody(
                 irWhen(
@@ -125,9 +146,20 @@ class BackInTimeDebuggableImplementTransformer : IrElementTransformerVoid() {
                         )
                     }.plus(
                         irElseBranch(
-                            irCall(throwNoSuchPropertyExceptionFunctionSymbol).apply {
-                                putValueArgument(0, irGet(propertyNameParameter))
-                                putValueArgument(1, irString(parentClass.kotlinFqName.asString()))
+                            if (superDeclarationSymbol != null && superClassSymbol != null && parentClassReceiver != null) {
+                                irCall(
+                                    callee = superDeclarationSymbol.owner,
+                                    superQualifierSymbol = superClassSymbol,
+                                ).apply {
+                                    dispatchReceiver = irGet(parentClassReceiver)
+                                    putValueArgument(0, irGet(propertyNameParameter))
+                                    putValueArgument(1, irGet(valueParameter))
+                                }
+                            } else {
+                                irCall(throwNoSuchPropertyExceptionFunctionSymbol).apply {
+                                    putValueArgument(0, irGet(propertyNameParameter))
+                                    putValueArgument(1, irString(parentClass.kotlinFqName.asString()))
+                                }
                             },
                         ),
                     ).toList(),
@@ -143,6 +175,11 @@ class BackInTimeDebuggableImplementTransformer : IrElementTransformerVoid() {
         val parentClass = declaration.parentAsClass
         val (propertyNameParameter, valueParameter) = declaration.valueParameters
         val irBuilder = irBuiltIns.createIrBuilder(declaration.symbol)
+
+        val superDeclarationSymbol = declaration.overriddenSymbols.firstOrNull { it.owner.modality == Modality.OPEN }
+        val superClassSymbol = parentClass.superClass?.symbol
+        val parentClassReceiver = declaration.dispatchReceiverParameter
+
         return with(irBuilder) {
             irExprBody(
                 irWhen(
@@ -158,9 +195,20 @@ class BackInTimeDebuggableImplementTransformer : IrElementTransformerVoid() {
                         )
                     }.plus(
                         irElseBranch(
-                            irCall(throwNoSuchPropertyExceptionFunctionSymbol).apply {
-                                putValueArgument(0, irGet(propertyNameParameter))
-                                putValueArgument(1, irString(parentClass.kotlinFqName.asString()))
+                            if (superDeclarationSymbol != null && superClassSymbol != null && parentClassReceiver != null) {
+                                irCall(
+                                    callee = superDeclarationSymbol.owner,
+                                    superQualifierSymbol = superClassSymbol,
+                                ).apply {
+                                    dispatchReceiver = irGet(parentClassReceiver)
+                                    putValueArgument(0, irGet(propertyNameParameter))
+                                    putValueArgument(1, irGet(valueParameter))
+                                }
+                            } else {
+                                irCall(throwNoSuchPropertyExceptionFunctionSymbol).apply {
+                                    putValueArgument(0, irGet(propertyNameParameter))
+                                    putValueArgument(1, irString(parentClass.kotlinFqName.asString()))
+                                }
                             },
                         ),
                     ).toList(),

--- a/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/implement/BackInTimeDebuggableImplementTransformer.kt
+++ b/backintime-plugin/compiler/src/main/kotlin/com/github/kitakkun/backintime/compiler/backend/transformer/implement/BackInTimeDebuggableImplementTransformer.kt
@@ -112,7 +112,7 @@ class BackInTimeDebuggableImplementTransformer : IrElementTransformerVoid() {
                                 putValueArgument(0, irGet(propertyNameParameter))
                                 putValueArgument(1, irString(parentClass.kotlinFqName.asString()))
                             }
-                        }
+                        },
                     ),
                 ).toList(),
             )

--- a/test/src/commonTest/kotlin/com/github/kitakkun/backintime/test/specific/InheritanceTest.kt
+++ b/test/src/commonTest/kotlin/com/github/kitakkun/backintime/test/specific/InheritanceTest.kt
@@ -14,6 +14,9 @@ class InheritanceTest : BackInTimeDebugServiceTest() {
     private open class SuperClass {
         var superProperty: String = "super"
         open var overridableProperty: String = "super"
+
+        private var privateSuperProperty = "private-super"
+        fun getPrivateSuperProperty() = privateSuperProperty
     }
 
     @BackInTime
@@ -52,5 +55,46 @@ class InheritanceTest : BackInTimeDebugServiceTest() {
         // sub class
         instance.forceSetValue("subProperty", "sub(modified)")
         assertEquals("sub(modified)", instance.subProperty)
+
+        // private property of super class
+        instance.forceSetValue("privateSuperProperty", "private-super(modified)")
+        assertEquals("private-super(modified)", instance.getPrivateSuperProperty())
+    }
+
+    @Test
+    fun testSerializeValue() {
+        val instance = SubClass()
+        assertIs<BackInTimeDebuggable>(instance)
+
+        // super class
+        assertEquals("\"string\"", instance.serializeValue("superProperty", "string"))
+
+        // overriding property
+        assertEquals("\"string\"", instance.serializeValue("overridableProperty", "string"))
+
+        // sub class
+        assertEquals("\"string\"", instance.serializeValue("subProperty", "string"))
+
+        // private property of super class
+        assertEquals("\"string\"", instance.serializeValue("privateSuperProperty", "string"))
+    }
+
+
+    @Test
+    fun testDeserializeValue() {
+        val instance = SubClass()
+        assertIs<BackInTimeDebuggable>(instance)
+
+        // super class
+        assertEquals("string", instance.deserializeValue("superProperty", "\"string\""))
+
+        // overriding property
+        assertEquals("string", instance.deserializeValue("overridableProperty", "\"string\""))
+
+        // sub class
+        assertEquals("string", instance.deserializeValue("subProperty", "\"string\""))
+
+        // private property of super class
+        assertEquals("string", instance.deserializeValue("privateSuperProperty", "\"string\""))
     }
 }

--- a/test/src/commonTest/kotlin/com/github/kitakkun/backintime/test/specific/InheritanceTest.kt
+++ b/test/src/commonTest/kotlin/com/github/kitakkun/backintime/test/specific/InheritanceTest.kt
@@ -79,7 +79,6 @@ class InheritanceTest : BackInTimeDebugServiceTest() {
         assertEquals("\"string\"", instance.serializeValue("privateSuperProperty", "string"))
     }
 
-
     @Test
     fun testDeserializeValue() {
         val instance = SubClass()


### PR DESCRIPTION
This PR fixes #88 

However, there are potential problems.
- let A be a superclass of B.
- A has a private member property named "prop".
- B has a member property named "prop".
- if we call B.forceSetProperty("prop", "value"), the property of B is prioritized. Thus, class A can't be back-in-time debuggable.