### PR TITLE
Fix: Jvm toolchain issue

### DIFF
--- a/backintime-runtime/build.gradle.kts
+++ b/backintime-runtime/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(17)
 
     jvm()
     androidTarget { publishAllLibraryVariants() }


### PR DESCRIPTION
When I tried to build this project on my M1 Macbook Air, I faced this build error.
```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':backintime-runtime:compileDebugKotlinAndroid'.
> Cannot find a Java installation on your machine matching this tasks requirements: {languageVersion=8, vendor=any, implementation=vendor-specific} for MAC_OS on aarch64.
   > No locally installed toolchains match and toolchain download repositories have not been configured.
```