### PR TITLE
Refactor gradle scripts

### DIFF
--- a/backintime-annotations/build.gradle.kts
+++ b/backintime-annotations/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.backintimeLint)
-    `maven-publish`
+    alias(libs.plugins.mavenPublish)
 }
 
 kotlin {

--- a/backintime-demo/app/build.gradle.kts
+++ b/backintime-demo/app/build.gradle.kts
@@ -54,9 +54,9 @@ android {
 }
 
 dependencies {
-    implementation(project(":backintime-runtime"))
-    implementation(project(":backintime-annotations"))
-    implementation(project(":backintime-websocket-event"))
+    implementation(projects.backintimeRuntime)
+    implementation(projects.backintimeAnnotations)
+    implementation(projects.backintimeWebsocketEvent)
     implementation(libs.core.ktx)
     implementation(libs.lifecycle.runtime.ktx)
     implementation(libs.activity.compose)

--- a/backintime-plugin/common/build.gradle.kts
+++ b/backintime-plugin/common/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.backintimeLint)
-    `maven-publish`
+    alias(libs.plugins.mavenPublish)
 }
 
 publishing {

--- a/backintime-plugin/compiler/build.gradle.kts
+++ b/backintime-plugin/compiler/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":backintime-plugin:common"))
-    implementation(project(":backintime-annotations"))
+    implementation(projects.backintimePlugin.common)
+    implementation(projects.backintimeAnnotations)
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlin.compiler.embeddable)
     implementation(libs.kotlinx.serialization.json)

--- a/backintime-plugin/compiler/build.gradle.kts
+++ b/backintime-plugin/compiler/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.backintimeLint)
-    `maven-publish`
+    alias(libs.plugins.mavenPublish)
 }
 
 dependencies {

--- a/backintime-plugin/gradle/build.gradle.kts
+++ b/backintime-plugin/gradle/build.gradle.kts
@@ -19,5 +19,5 @@ dependencies {
     implementation(projects.backintimePlugin.common)
     implementation(libs.kotlin.gradle.plugin.api)
     implementation(libs.kotlinx.serialization.json)
-    compileOnly(kotlin("gradle-plugin"))
+    compileOnly(libs.kotlin.gradle.plugin)
 }

--- a/backintime-plugin/gradle/build.gradle.kts
+++ b/backintime-plugin/gradle/build.gradle.kts
@@ -2,8 +2,8 @@ plugins {
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.backintimeLint)
-    `java-gradle-plugin`
-    `maven-publish`
+    alias(libs.plugins.javaGradlePlugin)
+    alias(libs.plugins.mavenPublish)
 }
 
 gradlePlugin {

--- a/backintime-plugin/gradle/build.gradle.kts
+++ b/backintime-plugin/gradle/build.gradle.kts
@@ -16,7 +16,7 @@ gradlePlugin {
 }
 
 dependencies {
-    implementation(project(":backintime-plugin:common"))
+    implementation(projects.backintimePlugin.common)
     implementation(libs.kotlin.gradle.plugin.api)
     implementation(libs.kotlinx.serialization.json)
     compileOnly(kotlin("gradle-plugin"))

--- a/backintime-runtime/build.gradle.kts
+++ b/backintime-runtime/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.androidLibrary)
-    `maven-publish`
+    alias(libs.plugins.mavenPublish)
 }
 
 kotlin {

--- a/backintime-runtime/build.gradle.kts
+++ b/backintime-runtime/build.gradle.kts
@@ -17,8 +17,8 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(project(":backintime-websocket-client"))
-            implementation(project(":backintime-websocket-event"))
+            implementation(projects.backintimeWebsocketClient)
+            implementation(projects.backintimeWebsocketEvent)
             implementation(libs.ktor.client.core)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.serialization.json)

--- a/backintime-websocket-client/build.gradle.kts
+++ b/backintime-websocket-client/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
-    `maven-publish`
+    alias(libs.plugins.mavenPublish)
 }
 
 kotlin {

--- a/backintime-websocket-client/build.gradle.kts
+++ b/backintime-websocket-client/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(project(":backintime-websocket-event"))
+            implementation(projects.backintimeWebsocketEvent)
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.client.cio)
             implementation(libs.ktor.client.websockets)

--- a/backintime-websocket-event/build.gradle.kts
+++ b/backintime-websocket-event/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.androidLibrary)
-    `maven-publish`
+    alias(libs.plugins.mavenPublish)
 }
 
 kotlin {

--- a/backintime-websocket-server/build.gradle.kts
+++ b/backintime-websocket-server/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
-    `maven-publish`
+    alias(libs.plugins.mavenPublish)
 }
 
 kotlin {

--- a/backintime-websocket-server/build.gradle.kts
+++ b/backintime-websocket-server/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(project(":backintime-websocket-event"))
+            implementation(projects.backintimeWebsocketEvent)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.ktor.server.cio)
             implementation(libs.ktor.server.websockets)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ kotlinx-datetime = "0.6.0"
 ktlint-gradle = { group = "org.jlleitschuh.gradle", name = "ktlint-gradle", version.ref = "ktlint-gradle" }
 
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
+kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradle-plugin-api = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin-api", version.ref = "kotlin" }
 kotlin-compiler-embeddable = { group = "org.jetbrains.kotlin", name = "kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -103,3 +103,5 @@ androidLibrary = { id = "com.android.library", version.ref = "android-library" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+mavenPublish = { id = "maven-publish" }
+javaGradlePlugin = { id = "java-gradle-plugin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ dependencyResolutionManagement {
     }
 }
 
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 rootProject.name = "backintime"
 
 include(

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -19,10 +19,10 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project(":backintime-runtime"))
-                implementation(project(":backintime-annotations"))
-                implementation(project(":backintime-websocket-server"))
-                implementation(project(":backintime-websocket-event"))
+                implementation(projects.backintimeRuntime)
+                implementation(projects.backintimeAnnotations)
+                implementation(projects.backintimeWebsocketServer)
+                implementation(projects.backintimeWebsocketEvent)
                 implementation(libs.kotlinx.coroutines.core)
                 implementation(libs.kotlinx.serialization.json)
             }


### PR DESCRIPTION
- Introduce `TYPESAFE_PROJECT_ACCESSORS`
- Replace `maven-publish` and `java-gradle-plugin` with version catalogs.
- Replace dependency with version catalog, whose definition depends on the Kotlin Gradle plugin.