### PR TITLE
Fix null value captures causing crashses

### DIFF
--- a/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/internal/CaptureUtils.kt
+++ b/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/internal/CaptureUtils.kt
@@ -5,7 +5,7 @@ package com.kitakkun.backintime.core.runtime.internal
 import com.kitakkun.backintime.core.runtime.BackInTimeDebuggable
 
 @BackInTimeCompilerInternalApi
-internal fun <T : Any> captureThenReturnValue(
+internal fun <T : Any?> captureThenReturnValue(
     instance: BackInTimeDebuggable,
     ownerClassFqName: String,
     methodInvocationId: String,


### PR DESCRIPTION
The typeParameter `T` on `captureThenReturnValue` function was non-nullable `Any`.
When trying to capture null value, it crashes.
This PR fixes this issue.