### PR TITLE
Refactor: Change internal signature expression to be based on kotlin classId and fqname

### DIFF
--- a/compiler-test/src/androidUnitTest/kotlin/com/kitakkun/backintime/test/WeirdCodeStyleViewModelTest.kt
+++ b/compiler-test/src/androidUnitTest/kotlin/com/kitakkun/backintime/test/WeirdCodeStyleViewModelTest.kt
@@ -10,21 +10,21 @@ class WeirdCodeStyleViewModelTest : BackInTimeDebugServiceTest() {
     fun mutateLiveData() {
         viewModel.mutateLiveData()
 
-        assertEquals(7, propertyValueChangeEvents.filter { it.propertyName == "mutableLiveData1" }.size)
-        assertEquals(1, propertyValueChangeEvents.filter { it.propertyName == "mutableLiveData2" }.size)
+        assertEquals(7, propertyValueChangeEvents.filter { it.propertySignature == "com/kitakkun/backintime/test/WeirdCodeStyleViewModel.mutableLiveData1" }.size)
+        assertEquals(1, propertyValueChangeEvents.filter { it.propertySignature == "com/kitakkun/backintime/test/WeirdCodeStyleViewModel.mutableLiveData2" }.size)
     }
 
     @Test
     fun mutateStateFlow() {
         viewModel.mutateStateFlow()
 
-        assertEquals(2, propertyValueChangeEvents.filter { it.propertyName == "mutableStateFlow" }.size)
+        assertEquals(2, propertyValueChangeEvents.filter { it.propertySignature == "com/kitakkun/backintime/test/WeirdCodeStyleViewModel.mutableStateFlow" }.size)
     }
 
     @Test
     fun mutateState() {
         viewModel.mutateState()
 
-        assertEquals(1, propertyValueChangeEvents.filter { it.propertyName == "mutableState" }.size)
+        assertEquals(1, propertyValueChangeEvents.filter { it.propertySignature == "com/kitakkun/backintime/test/WeirdCodeStyleViewModel.mutableState" }.size)
     }
 }

--- a/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/basic/MethodCallEventTest.kt
+++ b/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/basic/MethodCallEventTest.kt
@@ -31,8 +31,12 @@ class MethodCallEventTest : BackInTimeDebugServiceTest() {
 
         assertEquals(expected = 3, actual = notifyMethodCallEvents.size)
         assertContentEquals(
-            expected = listOf("method1", "method2", "method3"),
-            actual = notifyMethodCallEvents.map { it.methodName },
+            expected = listOf(
+                "com/kitakkun/backintime/test/basic/MethodCallEventTest.TestStateHolder.method1():kotlin/Unit",
+                "com/kitakkun/backintime/test/basic/MethodCallEventTest.TestStateHolder.method2():kotlin/Unit",
+                "com/kitakkun/backintime/test/basic/MethodCallEventTest.TestStateHolder.method3():kotlin/Unit",
+            ),
+            actual = notifyMethodCallEvents.map { it.methodSignature },
         )
     }
 }

--- a/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/basic/MethodGenerationTest.kt
+++ b/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/basic/MethodGenerationTest.kt
@@ -8,11 +8,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 class MethodGenerationTest : BackInTimeDebugServiceTest() {
-    companion object {
-        private const val CLASS_FQ_NAME = "com.kitakkun.backintime.test.basic.MethodGenerationTest.TestStateHolder"
-        private const val PROPERTY_NAME = "property"
-    }
-
     @BackInTime
     private class TestStateHolder {
         var property: Int = 0
@@ -24,7 +19,7 @@ class MethodGenerationTest : BackInTimeDebugServiceTest() {
 
         assertIs<BackInTimeDebuggable>(holder)
 
-        holder.forceSetValue(propertyOwnerClassFqName = CLASS_FQ_NAME, propertyName = PROPERTY_NAME, value = "10")
+        holder.forceSetValue(propertySignature = "com/kitakkun/backintime/test/basic/MethodGenerationTest.TestStateHolder.property", jsonValue = "10")
         assertEquals(10, holder.property)
     }
 }

--- a/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/basic/PropertyChangeEventTest.kt
+++ b/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/basic/PropertyChangeEventTest.kt
@@ -10,11 +10,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 class PropertyChangeEventTest : BackInTimeDebugServiceTest() {
-    companion object {
-        private const val CLASS_FQ_NAME = "com.kitakkun.backintime.test.basic.PropertyChangeEventTest.TestStateHolder"
-        private const val PROPERTY_NAME = "property"
-    }
-
     @BackInTime
     class TestStateHolder {
         var property: Int = 0
@@ -32,8 +27,7 @@ class PropertyChangeEventTest : BackInTimeDebugServiceTest() {
         delay(100)
         assertEquals(expected = 1, actual = notifyValueChangeEvents.size)
         assertEquals(holder.backInTimeInstanceUUID, notifyValueChangeEvents[0].instanceUUID)
-        assertEquals(expected = CLASS_FQ_NAME, actual = notifyValueChangeEvents[0].ownerClassFqName)
-        assertEquals(expected = PROPERTY_NAME, actual = notifyValueChangeEvents[0].propertyName)
+        assertEquals(expected = "com/kitakkun/backintime/test/basic/PropertyChangeEventTest.TestStateHolder.property", actual = notifyValueChangeEvents[0].propertySignature)
         assertEquals(expected = 1, actual = notifyValueChangeEvents[0].value.toInt())
 
         // external access can't be captured

--- a/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/exception/NoSuchPropertyExceptionTest.kt
+++ b/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/exception/NoSuchPropertyExceptionTest.kt
@@ -18,7 +18,7 @@ class NoSuchPropertyExceptionTest {
         val holder = TestStateHolder()
         assertIs<BackInTimeDebuggable>(holder)
         assertFailsWith(BackInTimeRuntimeException.NoSuchPropertyException::class) {
-            holder.forceSetValue("", "property2", "test")
+            holder.forceSetValue("com/kitakkun/backintime/test/exception/NoSuchPropertyExceptionTest/TestStateHolder.property2", "test")
         }
     }
 }

--- a/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/specific/AnnotationConfiguredValueContainerTest.kt
+++ b/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/specific/AnnotationConfiguredValueContainerTest.kt
@@ -15,8 +15,7 @@ import kotlin.test.assertIs
 
 class AnnotationConfiguredValueContainerTest : BackInTimeDebugServiceTest() {
     companion object {
-        private const val CLASS_FQ_NAME = "com.kitakkun.backintime.test.specific.AnnotationConfiguredValueContainerTest.ValueContainerHolder"
-        private const val CONTAINER_NAME = "container"
+        private const val CONTAINER_PROPERTY_SIGNATURE = "com/kitakkun/backintime/test/specific/AnnotationConfiguredValueContainerTest.ValueContainerHolder.container"
     }
 
     @ValueContainer
@@ -49,7 +48,7 @@ class AnnotationConfiguredValueContainerTest : BackInTimeDebugServiceTest() {
         assertEquals(10, holder.container.value)
         assertEquals(1, notifyValueChangeEvents.size)
         assertEquals(holder.backInTimeInstanceUUID, notifyValueChangeEvents[0].instanceUUID)
-        assertEquals(CONTAINER_NAME, notifyValueChangeEvents[0].propertyName)
+        assertEquals(CONTAINER_PROPERTY_SIGNATURE, notifyValueChangeEvents[0].propertySignature)
         assertEquals(10, notifyValueChangeEvents[0].value.toInt())
     }
 
@@ -58,7 +57,7 @@ class AnnotationConfiguredValueContainerTest : BackInTimeDebugServiceTest() {
         val holder = ValueContainerHolder()
         assertIs<BackInTimeDebuggable>(holder)
 
-        holder.forceSetValue(propertyOwnerClassFqName = CLASS_FQ_NAME, propertyName = CONTAINER_NAME, value = "10")
+        holder.forceSetValue(propertySignature = CONTAINER_PROPERTY_SIGNATURE, jsonValue = "10")
         assertEquals(10, holder.container.value)
     }
 }

--- a/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/specific/InheritanceTest.kt
+++ b/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/specific/InheritanceTest.kt
@@ -38,9 +38,9 @@ class InheritanceTest : BackInTimeDebugServiceTest() {
 
         assertEquals(2, registerInstanceEvents.size)
         assertEquals(instance.backInTimeInstanceUUID, registerInstanceEvents[0].instanceUUID) // super class
-        assertEquals("com/kitakkun/backintime/test/specific/InheritanceTest.SuperClass", registerInstanceEvents[0].className) // super class
+        assertEquals("com/kitakkun/backintime/test/specific/InheritanceTest.SuperClass", registerInstanceEvents[0].classSignature) // super class
         assertEquals(instance.backInTimeInstanceUUID, registerInstanceEvents[1].instanceUUID) // sub class
-        assertEquals("com/kitakkun/backintime/test/specific/InheritanceTest.SubClass", registerInstanceEvents[1].className) // super class
+        assertEquals("com/kitakkun/backintime/test/specific/InheritanceTest.SubClass", registerInstanceEvents[1].classSignature) // super class
     }
 
     @Test

--- a/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/specific/InheritanceTest.kt
+++ b/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/specific/InheritanceTest.kt
@@ -10,17 +10,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 class InheritanceTest : BackInTimeDebugServiceTest() {
-    companion object {
-        private const val SUPER_CLASS_FQ_NAME = "com.kitakkun.backintime.test.specific.InheritanceTest.SuperClass"
-        private const val SUPER_PROPERTY_NAME = "superProperty"
-        private const val OVERRIDABLE_PROPERTY_NAME = "overridableProperty"
-        private const val PRIVATE_SUPER_PROPERTY_NAME = "privateSuperProperty"
-        private const val SUPER_CLASS_CONFLICTED_PRIVATE_PROPERTY_NAME = "conflictedPrivateProperty"
-        private const val SUB_CLASS_FQ_NAME = "com.kitakkun.backintime.test.specific.InheritanceTest.SubClass"
-        private const val SUB_PROPERTY_NAME = "subProperty"
-        private const val SUB_CLASS_CONFLICTED_PRIVATE_PROPERTY_NAME = "conflictedPrivateProperty"
-    }
-
     @BackInTime
     private open class SuperClass {
         var superProperty: String = "super"
@@ -49,9 +38,9 @@ class InheritanceTest : BackInTimeDebugServiceTest() {
 
         assertEquals(2, registerInstanceEvents.size)
         assertEquals(instance.backInTimeInstanceUUID, registerInstanceEvents[0].instanceUUID) // super class
-        assertEquals("com.kitakkun.backintime.test.specific.InheritanceTest.SuperClass", registerInstanceEvents[0].className) // super class
+        assertEquals("com/kitakkun/backintime/test/specific/InheritanceTest.SuperClass", registerInstanceEvents[0].className) // super class
         assertEquals(instance.backInTimeInstanceUUID, registerInstanceEvents[1].instanceUUID) // sub class
-        assertEquals("com.kitakkun.backintime.test.specific.InheritanceTest.SubClass", registerInstanceEvents[1].className) // super class
+        assertEquals("com/kitakkun/backintime/test/specific/InheritanceTest.SubClass", registerInstanceEvents[1].className) // super class
     }
 
     @Test
@@ -60,19 +49,19 @@ class InheritanceTest : BackInTimeDebugServiceTest() {
         assertIs<BackInTimeDebuggable>(instance)
 
         // super class
-        instance.forceSetValue(SUPER_CLASS_FQ_NAME, SUPER_PROPERTY_NAME, "\"super(modified)\"")
+        instance.forceSetValue("com/kitakkun/backintime/test/specific/InheritanceTest.SuperClass.superProperty", "\"super(modified)\"")
         assertEquals("super(modified)", instance.superProperty)
 
         // overriding property
-        instance.forceSetValue(SUPER_CLASS_FQ_NAME, OVERRIDABLE_PROPERTY_NAME, "\"overridable(modified)\"")
+        instance.forceSetValue("com/kitakkun/backintime/test/specific/InheritanceTest.SuperClass.overridableProperty", "\"overridable(modified)\"")
         assertEquals("overridable(modified)", instance.overridableProperty)
 
         // sub class
-        instance.forceSetValue(SUB_CLASS_FQ_NAME, SUB_PROPERTY_NAME, "\"sub(modified)\"")
+        instance.forceSetValue("com/kitakkun/backintime/test/specific/InheritanceTest.SubClass.subProperty", "\"sub(modified)\"")
         assertEquals("sub(modified)", instance.subProperty)
 
         // private property of super class
-        instance.forceSetValue(SUPER_CLASS_FQ_NAME, PRIVATE_SUPER_PROPERTY_NAME, "\"private-super(modified)\"")
+        instance.forceSetValue("com/kitakkun/backintime/test/specific/InheritanceTest.SuperClass.privateSuperProperty", "\"private-super(modified)\"")
         assertEquals("private-super(modified)", instance.getPrivateSuperProperty())
     }
 
@@ -81,11 +70,11 @@ class InheritanceTest : BackInTimeDebugServiceTest() {
         val instance = SubClass()
         assertIs<BackInTimeDebuggable>(instance)
 
-        instance.forceSetValue(SUB_CLASS_FQ_NAME, SUB_CLASS_CONFLICTED_PRIVATE_PROPERTY_NAME, "\"conflict(update-sub)\"")
+        instance.forceSetValue("com/kitakkun/backintime/test/specific/InheritanceTest.SubClass.conflictedPrivateProperty", "\"conflict(update-sub)\"")
         assertEquals(expected = "conflict(update-sub)", actual = instance.getSubPrivateConflictedProperty())
         assertEquals(expected = "conflict", actual = instance.getSuperPrivateConflictedProperty())
 
-        instance.forceSetValue(SUPER_CLASS_FQ_NAME, SUPER_CLASS_CONFLICTED_PRIVATE_PROPERTY_NAME, "\"conflict(update-super)\"")
+        instance.forceSetValue("com/kitakkun/backintime/test/specific/InheritanceTest.SuperClass.conflictedPrivateProperty", "\"conflict(update-super)\"")
         assertEquals(expected = "conflict(update-sub)", actual = instance.getSubPrivateConflictedProperty())
         assertEquals(expected = "conflict(update-super)", actual = instance.getSuperPrivateConflictedProperty())
     }

--- a/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/specific/PureVarsHolderTest.kt
+++ b/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/specific/PureVarsHolderTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertIs
 
 class PureVarsHolderTest {
     companion object {
-        private const val HOLDER_CLASS_FQ_NAME = "com.kitakkun.backintime.test.specific.PureVarsHolderTest.PureVarsHolder"
+        private const val HOLDER_CLASS_FQ_NAME = "com/kitakkun/backintime/test/specific/PureVarsHolderTest.PureVarsHolder"
     }
 
     @BackInTime
@@ -44,41 +44,41 @@ class PureVarsHolderTest {
         val holder = PureVarsHolder()
         assertIs<BackInTimeDebuggable>(holder)
 
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "string", "\"hogehoge\"")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.string", "\"hogehoge\"")
         assertEquals("hogehoge", holder.string)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "int", "0")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.int", "0")
         assertEquals(0, holder.int)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "long", "0")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.long", "0")
         assertEquals(0L, holder.long)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "float", "0")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.float", "0")
         assertEquals(0f, holder.float)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "double", "0.0")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.double", "0.0")
         assertEquals(0.0, holder.double)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "boolean", "false")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.boolean", "false")
         assertEquals(false, holder.boolean)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "char", "a")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.char", "a")
         assertEquals('a', holder.char)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "short", "0")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.short", "0")
         assertEquals(0.toShort(), holder.short)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "byte", "0")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.byte", "0")
         assertEquals(0.toByte(), holder.byte)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "nullableString", "null")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.nullableString", "null")
         assertEquals(null, holder.nullableString)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "nullableInt", "null")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.nullableInt", "null")
         assertEquals(null, holder.nullableInt)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "nullableLong", "null")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.nullableLong", "null")
         assertEquals(null, holder.nullableLong)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "nullableFloat", "null")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.nullableFloat", "null")
         assertEquals(null, holder.nullableFloat)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "nullableDouble", "null")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.nullableDouble", "null")
         assertEquals(null, holder.nullableDouble)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "nullableBoolean", "null")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.nullableBoolean", "null")
         assertEquals(null, holder.nullableBoolean)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "nullableChar", "null")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.nullableChar", "null")
         assertEquals(null, holder.nullableChar)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "nullableShort", "null")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.nullableShort", "null")
         assertEquals(null, holder.nullableShort)
-        holder.forceSetValue(HOLDER_CLASS_FQ_NAME, "nullableByte", "null")
+        holder.forceSetValue("$HOLDER_CLASS_FQ_NAME.nullableByte", "null")
         assertEquals(null, holder.nullableByte)
     }
 }

--- a/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/specific/ScopeFunctionsTest.kt
+++ b/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/specific/ScopeFunctionsTest.kt
@@ -14,11 +14,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 class ScopeFunctionsTest : BackInTimeDebugServiceTest() {
-    companion object {
-        private const val CLASS_FQ_NAME = "com.kitakkun.backintime.test.specific.ScopeFunctionsTest.ValueContainerHolder"
-        private const val CONTAINER_PROPERTY_NAME = "container"
-    }
-
     @ValueContainer
     private class AnnotationConfiguredValueContainer<T>(
         @Getter @Setter @Capture var value: T,
@@ -130,8 +125,7 @@ class ScopeFunctionsTest : BackInTimeDebugServiceTest() {
         assertEquals(10, container.value)
         assertEquals(1, notifyValueChangeEvents.size)
         assertEquals(this.backInTimeInstanceUUID, notifyValueChangeEvents[0].instanceUUID)
-        assertEquals(CLASS_FQ_NAME, notifyValueChangeEvents[0].ownerClassFqName)
-        assertEquals(CONTAINER_PROPERTY_NAME, notifyValueChangeEvents[0].propertyName)
+        assertEquals("com/kitakkun/backintime/test/specific/ScopeFunctionsTest.ValueContainerHolder.container", notifyValueChangeEvents[0].propertySignature)
         assertEquals(10, notifyValueChangeEvents[0].value.toInt())
     }
 }

--- a/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/specific/SelfSerializableValueHolderTest.kt
+++ b/compiler-test/src/commonTest/kotlin/com/kitakkun/backintime/test/specific/SelfSerializableValueHolderTest.kt
@@ -7,11 +7,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 class SelfSerializableValueHolderTest {
-    companion object {
-        private const val CLASS_FQ_NAME = "com.kitakkun.backintime.test.specific.SelfSerializableValueHolderTest.TestStateHolder"
-        private const val MUTABLE_LIST_PROPERTY_NAME = "mutableList"
-    }
-
     @BackInTime
     private class TestStateHolder {
         val mutableList = mutableListOf<String>()
@@ -22,7 +17,7 @@ class SelfSerializableValueHolderTest {
         val holder = TestStateHolder()
         assertIs<BackInTimeDebuggable>(holder)
 
-        holder.forceSetValue(CLASS_FQ_NAME, MUTABLE_LIST_PROPERTY_NAME, "[\"Hello\"]")
+        holder.forceSetValue("com/kitakkun/backintime/test/specific/SelfSerializableValueHolderTest.TestStateHolder.mutableList", "[\"Hello\"]")
         assertEquals(listOf("Hello"), holder.mutableList)
     }
 }

--- a/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/transformer/capture/BackInTimeDebuggableConstructorTransformer.kt
+++ b/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/transformer/capture/BackInTimeDebuggableConstructorTransformer.kt
@@ -1,7 +1,6 @@
 package com.kitakkun.backintime.compiler.backend.transformer.capture
 
 import com.kitakkun.backintime.compiler.backend.BackInTimePluginContext
-import com.kitakkun.backintime.compiler.backend.utils.getCompletedName
 import com.kitakkun.backintime.compiler.backend.utils.getGenericTypes
 import com.kitakkun.backintime.compiler.backend.utils.isBackInTimeDebuggable
 import com.kitakkun.backintime.compiler.backend.utils.isBackInTimeGenerated
@@ -82,8 +81,8 @@ class BackInTimeDebuggableConstructorTransformer : IrElementTransformerVoid() {
                     .filter { !it.isBackInTimeGenerated }
                     .map { irProperty ->
                         val propertyType = irProperty.getter?.returnType as? IrSimpleType
-                        val propertyTypeName = propertyType?.classOrNull?.owner?.signatureForBackInTimeDebugger() ?: "unknown"
-                        val genericTypeCompletedName = (propertyType?.getGenericTypes()?.firstOrNull() as? IrSimpleType)?.getCompletedName() ?: propertyTypeName
+                        val propertyTypeName = propertyType?.signatureForBackInTimeDebugger() ?: "unknown"
+                        val genericTypeCompletedName = propertyType?.getGenericTypes()?.firstOrNull()?.signatureForBackInTimeDebugger() ?: propertyTypeName
                         // FIXME: 必ずしも正確な判定ではない
                         val isDebuggable = irProperty.isVar || propertyType?.classOrNull in valueContainerClassInfoList.map { it.classSymbol }
                         val isDebuggableStateHolder = propertyType?.classOrNull?.owner?.hasAnnotation(BackInTimeAnnotations.backInTimeAnnotationFqName) ?: false

--- a/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/transformer/capture/BackInTimeDebuggableConstructorTransformer.kt
+++ b/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/transformer/capture/BackInTimeDebuggableConstructorTransformer.kt
@@ -4,8 +4,9 @@ import com.kitakkun.backintime.compiler.backend.BackInTimePluginContext
 import com.kitakkun.backintime.compiler.backend.utils.getCompletedName
 import com.kitakkun.backintime.compiler.backend.utils.getGenericTypes
 import com.kitakkun.backintime.compiler.backend.utils.isBackInTimeDebuggable
+import com.kitakkun.backintime.compiler.backend.utils.isBackInTimeGenerated
+import com.kitakkun.backintime.compiler.backend.utils.signatureForBackInTimeDebugger
 import com.kitakkun.backintime.compiler.common.BackInTimeAnnotations
-import com.kitakkun.backintime.compiler.common.BackInTimeConsts
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
@@ -21,10 +22,8 @@ import org.jetbrains.kotlin.ir.declarations.IrConstructor
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
 import org.jetbrains.kotlin.ir.types.IrSimpleType
-import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.ir.types.defaultType
-import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.util.properties
@@ -47,8 +46,8 @@ class BackInTimeDebuggableConstructorTransformer : IrElementTransformerVoid() {
             /** see [com.kitakkun.backintime.core.runtime.event.BackInTimeDebuggableInstanceEvent.RegisterTarget] */
             irCall(reportInstanceRegistrationFunctionSymbol).apply {
                 putValueArgument(0, irGet(parentClass.thisReceiver!!))
-                putValueArgument(1, irString(parentClass.fqNameWhenAvailable?.asString() ?: "unknown"))
-                putValueArgument(2, irString(parentClass.superClass?.fqNameWhenAvailable?.asString() ?: "unknown"))
+                putValueArgument(1, irString(parentClass.signatureForBackInTimeDebugger()))
+                putValueArgument(2, irString(parentClass.superClass?.signatureForBackInTimeDebugger() ?: "unknown"))
                 putValueArgument(3, generatePropertiesInfo(parentClass.properties))
             }
         }
@@ -80,16 +79,16 @@ class BackInTimeDebuggableConstructorTransformer : IrElementTransformerVoid() {
             irVararg(
                 propertyInfoClass.defaultType,
                 properties
-                    .filter { it.name != BackInTimeConsts.backInTimeInstanceUUIDName && it.name != BackInTimeConsts.backInTimeInitializedPropertyMapName }
+                    .filter { !it.isBackInTimeGenerated }
                     .map { irProperty ->
                         val propertyType = irProperty.getter?.returnType as? IrSimpleType
-                        val propertyTypeName = propertyType?.classFqName?.asString() ?: "unknown"
+                        val propertyTypeName = propertyType?.classOrNull?.owner?.signatureForBackInTimeDebugger() ?: "unknown"
                         val genericTypeCompletedName = (propertyType?.getGenericTypes()?.firstOrNull() as? IrSimpleType)?.getCompletedName() ?: propertyTypeName
                         // FIXME: 必ずしも正確な判定ではない
                         val isDebuggable = irProperty.isVar || propertyType?.classOrNull in valueContainerClassInfoList.map { it.classSymbol }
                         val isDebuggableStateHolder = propertyType?.classOrNull?.owner?.hasAnnotation(BackInTimeAnnotations.backInTimeAnnotationFqName) ?: false
                         irCallConstructor(propertyInfoClassConstructor, emptyList()).apply {
-                            putValueArgument(0, irString(irProperty.name.asString()))
+                            putValueArgument(0, irString(irProperty.signatureForBackInTimeDebugger()))
                             putValueArgument(1, irBoolean(isDebuggable || isDebuggableStateHolder))
                             putValueArgument(2, irBoolean(isDebuggableStateHolder))
                             putValueArgument(3, irString(propertyTypeName))

--- a/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/transformer/implement/BackInTimeDebuggableImplementTransformer.kt
+++ b/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/transformer/implement/BackInTimeDebuggableImplementTransformer.kt
@@ -58,16 +58,12 @@ class BackInTimeDebuggableImplementTransformer : IrElementTransformerVoid() {
     /**
      * generate body for [com.kitakkun.backintime.core.runtime.BackInTimeDebuggable.forceSetValue]:
      * ```kotlin
-     * fun forceSetValue(propertyOwnerClassFqName: String, propertyName: String, value: Any?) {
-     *     if (ownerClassFqName == "com.example.MyClass") {
-     *         when (propertyName) {
-     *             "prop1" -> prop1 = value
-     *             "prop2" -> prop3 = value
-     *             ...
-     *             else -> throw NoSuchPropertyException(...)
-     *         }
-     *     } else {
-     *         super.forceSetValue(ownerClassFqName, propertyName, value)
+     * // assume that this function is generated for the class com/example/MyClass
+     * fun forceSetValue(propertySignature: String, jsonValue: String) {
+     *     when (propertySignature) {
+     *         "com/example/MyClass.prop1" -> prop1 = backInTimeJson.decodeFromString(jsonValue)
+     *         "com/example/MyClass.prop2" -> prop2 = backInTimeJson.decodeFromString(jsonValue)
+     *         else -> super.forceSetValue(propertySignature, jsonValue) // if there's no super class, `throw NoSuchPropertyException(...)`
      *     }
      * }
      * ```

--- a/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/utils/BackInTimeIrGenerateUtils.kt
+++ b/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/utils/BackInTimeIrGenerateUtils.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.ir.types.classOrNull
 
 context(IrBuilderWithScope, BackInTimePluginContext)
 private fun irCapturePropertyValue(
-    propertyFqName: String,
+    propertySignature: String,
     getValueCall: IrCall,
     instanceParameter: IrValueParameter,
     uuidVariable: IrVariable,
@@ -24,7 +24,7 @@ private fun irCapturePropertyValue(
 ) = irCall(reportPropertyValueChangeFunctionSymbol).apply {
     putValueArgument(0, irGet(instanceParameter))
     putValueArgument(1, irGet(uuidVariable))
-    putValueArgument(2, irString(propertyFqName))
+    putValueArgument(2, irString(propertySignature))
     putValueArgument(3, getValueCall)
     putTypeArgument(0, propertyType.getSerializerType())
 }
@@ -37,7 +37,7 @@ fun IrProperty.generateCaptureValueCallForValueContainer(
     val getter = getter ?: return null
     val valueGetterSymbol = getValueHolderValueGetterSymbol() ?: return null
     return irCapturePropertyValue(
-        propertyFqName = signatureForBackInTimeDebugger(),
+        propertySignature = signatureForBackInTimeDebugger(),
         getValueCall = if (valueGetterSymbol == getter.symbol) {
             irCall(getter.symbol).apply {
                 dispatchReceiver = irGet(instanceParameter)

--- a/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/utils/BackInTimeIrGenerateUtils.kt
+++ b/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/utils/BackInTimeIrGenerateUtils.kt
@@ -13,12 +13,9 @@ import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classOrNull
-import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
-import org.jetbrains.kotlin.ir.util.parentClassOrNull
 
 context(IrBuilderWithScope, BackInTimePluginContext)
-fun irCapturePropertyValue(
-    ownerClassName: String,
+private fun irCapturePropertyValue(
     propertyFqName: String,
     getValueCall: IrCall,
     instanceParameter: IrValueParameter,
@@ -26,10 +23,9 @@ fun irCapturePropertyValue(
     propertyType: IrType,
 ) = irCall(reportPropertyValueChangeFunctionSymbol).apply {
     putValueArgument(0, irGet(instanceParameter))
-    putValueArgument(1, irString(ownerClassName))
-    putValueArgument(2, irGet(uuidVariable))
-    putValueArgument(3, irString(propertyFqName))
-    putValueArgument(4, getValueCall)
+    putValueArgument(1, irGet(uuidVariable))
+    putValueArgument(2, irString(propertyFqName))
+    putValueArgument(3, getValueCall)
     putTypeArgument(0, propertyType.getSerializerType())
 }
 
@@ -41,8 +37,7 @@ fun IrProperty.generateCaptureValueCallForValueContainer(
     val getter = getter ?: return null
     val valueGetterSymbol = getValueHolderValueGetterSymbol() ?: return null
     return irCapturePropertyValue(
-        ownerClassName = parentClassOrNull?.fqNameWhenAvailable?.asString() ?: return null,
-        propertyFqName = name.asString(),
+        propertyFqName = signatureForBackInTimeDebugger(),
         getValueCall = if (valueGetterSymbol == getter.symbol) {
             irCall(getter.symbol).apply {
                 dispatchReceiver = irGet(instanceParameter)

--- a/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/utils/IrTypeUtils.kt
+++ b/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/utils/IrTypeUtils.kt
@@ -4,7 +4,6 @@ import com.kitakkun.backintime.compiler.backend.BackInTimePluginContext
 import com.kitakkun.backintime.compiler.backend.valuecontainer.ResolvedValueContainer
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.IrType
-import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.ir.types.typeOrFail
 import org.jetbrains.kotlin.ir.types.typeOrNull
@@ -15,16 +14,6 @@ fun IrType.getGenericTypes(): List<IrType> {
         ?.arguments
         ?.mapNotNull { it.typeOrNull }
         .orEmpty()
-}
-
-fun IrSimpleType.getCompletedName(): String? {
-    if (this.arguments.isEmpty()) {
-        return this.classFqName?.asString()
-    } else {
-        val typeArgumentNames = this.arguments.map { (it.typeOrNull as? IrSimpleType)?.getCompletedName() }
-        if (typeArgumentNames.any { it == null }) return null
-        return this.classFqName?.asString() + typeArgumentNames.joinToString(prefix = "<", postfix = ">") { it!! }
-    }
 }
 
 context(BackInTimePluginContext)

--- a/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/utils/SignatureUtils.kt
+++ b/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/utils/SignatureUtils.kt
@@ -3,7 +3,10 @@ package com.kitakkun.backintime.compiler.backend.utils
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrProperty
-import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
+import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.types.classifierOrNull
 import org.jetbrains.kotlin.ir.util.classId
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
 
@@ -21,7 +24,7 @@ import org.jetbrains.kotlin.ir.util.parentClassOrNull
  */
 fun IrProperty.signatureForBackInTimeDebugger(): String {
     return StringBuilder().apply {
-        parentClassOrNull?.classId?.asString()?.let {
+        parentClassOrNull?.signatureForBackInTimeDebugger()?.let {
             this.append(it)
             this.append(".")
         }
@@ -60,12 +63,12 @@ fun IrProperty.signatureForBackInTimeDebugger(): String {
  * The signature for `member` will be: "com/example/B com/example/A.member(kotlin/Int):kotlin/String"
  */
 fun IrFunction.signatureForBackInTimeDebugger(): String {
-    val extensionReceiverSignature = extensionReceiverParameter?.type?.classOrNull?.owner?.signatureForBackInTimeDebugger()
-    val dispatchReceiverSignature = dispatchReceiverParameter?.type?.classOrNull?.owner?.signatureForBackInTimeDebugger()
+    val extensionReceiverSignature = extensionReceiverParameter?.type?.signatureForBackInTimeDebugger()
+    val dispatchReceiverSignature = dispatchReceiverParameter?.type?.signatureForBackInTimeDebugger()
     val valueParametersSignature = valueParameters
-        .map { it.type.classOrNull?.owner?.signatureForBackInTimeDebugger()!! }
+        .map { it.type.signatureForBackInTimeDebugger() }
         .joinToString(",")
-    val returnTypeSignature = returnType.classOrNull?.owner?.signatureForBackInTimeDebugger()!!
+    val returnTypeSignature = returnType.signatureForBackInTimeDebugger()
 
     return StringBuilder().apply {
         extensionReceiverSignature?.let {
@@ -98,4 +101,12 @@ fun IrFunction.signatureForBackInTimeDebugger(): String {
  */
 fun IrClass.signatureForBackInTimeDebugger(): String {
     return classId?.asString() ?: "unknown"
+}
+
+fun IrType.signatureForBackInTimeDebugger(): String {
+    return when (val classifierOrNull = this.classifierOrNull) {
+        is IrTypeParameterSymbol -> classifierOrNull.owner.name.asString()
+        is IrClassSymbol -> classifierOrNull.owner.signatureForBackInTimeDebugger()
+        else -> "unknown"
+    }
 }

--- a/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/utils/SignatureUtils.kt
+++ b/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/utils/SignatureUtils.kt
@@ -1,0 +1,101 @@
+package com.kitakkun.backintime.compiler.backend.utils
+
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrProperty
+import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.util.classId
+import org.jetbrains.kotlin.ir.util.parentClassOrNull
+
+/**
+ * ```kotlin
+ * package com.example
+ *
+ * class A {
+ *     val prop: Int = 10
+ * }
+ * ```
+ *
+ * The signature for `prop` will be: com/example/A.prop
+ * Note that extension properties are not supported because of no-need for debugging(We can't define no-backing-field extension properties for now).
+ */
+fun IrProperty.signatureForBackInTimeDebugger(): String {
+    return StringBuilder().apply {
+        parentClassOrNull?.classId?.asString()?.let {
+            this.append(it)
+            this.append(".")
+        }
+        append(this@signatureForBackInTimeDebugger.name.asString())
+    }.toString()
+}
+
+/**
+ * ```kotlin
+ * package com.example
+ *
+ * class A {
+ *     fun member(a: Int): String {
+ *         ...
+ *     }
+ * }
+ * ```
+ *
+ * The signature for `member` will be: "com/example/A.member(kotlin/Int):kotlin/String"
+ *
+ * Note:
+ * If the function has an extensionReceiver, the signature above will follow after the signature for the extensionReceiver class.
+ *
+ * ```kotlin
+ * package com.example
+ *
+ * class A {
+ *     fun B.member(a: Int): String {
+ *         ...
+ *     }
+ * }
+ *
+ * class B
+ * ```
+ *
+ * The signature for `member` will be: "com/example/B com/example/A.member(kotlin/Int):kotlin/String"
+ */
+fun IrFunction.signatureForBackInTimeDebugger(): String {
+    val extensionReceiverSignature = extensionReceiverParameter?.type?.classOrNull?.owner?.signatureForBackInTimeDebugger()
+    val dispatchReceiverSignature = dispatchReceiverParameter?.type?.classOrNull?.owner?.signatureForBackInTimeDebugger()
+    val valueParametersSignature = valueParameters
+        .map { it.type.classOrNull?.owner?.signatureForBackInTimeDebugger()!! }
+        .joinToString(",")
+    val returnTypeSignature = returnType.classOrNull?.owner?.signatureForBackInTimeDebugger()!!
+
+    return StringBuilder().apply {
+        extensionReceiverSignature?.let {
+            append(it)
+            append(" ")
+        }
+        dispatchReceiverSignature?.let {
+            append(it)
+            append(".")
+        }
+        append(name.asString())
+        append("(")
+        append(valueParametersSignature)
+        append(")")
+        append(":")
+        append(returnTypeSignature)
+    }.toString()
+}
+
+/**
+ *```kotlin
+ * package com.example
+ *
+ * class A {
+ *     class B
+ * }
+ * ```
+ *
+ * The signature for `B` will be: com/example/A.B
+ */
+fun IrClass.signatureForBackInTimeDebugger(): String {
+    return classId?.asString() ?: "unknown"
+}

--- a/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/BackInTimeDebugServiceImpl.kt
+++ b/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/BackInTimeDebugServiceImpl.kt
@@ -131,7 +131,7 @@ class BackInTimeDebugServiceImpl(
             classSignature = event.classSignature,
             superClassSignature = event.superClassSignature,
             properties = event.properties,
-            registeredAt = Clock.System.now().epochSeconds,
+            registeredAt = Clock.System.now().epochSeconds.toInt(),
         )
     }
 
@@ -144,7 +144,7 @@ class BackInTimeDebugServiceImpl(
         instanceUUID = event.instance.backInTimeInstanceUUID,
         methodSignature = event.methodSignature,
         methodCallUUID = event.methodCallId,
-        calledAt = Clock.System.now().epochSeconds,
+        calledAt = Clock.System.now().epochSeconds.toInt(),
     )
 
     private fun notifyPropertyChanged(event: BackInTimeDebuggableInstanceEvent.PropertyValueChange): BackInTimeDebugServiceEvent {

--- a/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/BackInTimeDebugServiceImpl.kt
+++ b/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/BackInTimeDebugServiceImpl.kt
@@ -104,10 +104,9 @@ class BackInTimeDebugServiceImpl(
 
             is BackInTimeDebuggerEvent.ForceSetPropertyValue -> {
                 forceSetValue(
-                    instanceId = event.instanceUUID,
-                    propertyOwnerClassName = event.ownerClassFqName,
-                    propertyName = event.propertyName,
-                    value = event.value,
+                    instanceId = event.targetInstanceId,
+                    propertySignature = event.propertySignature,
+                    jsonValue = event.jsonValue,
                 )
                 null
             }
@@ -143,18 +142,16 @@ class BackInTimeDebugServiceImpl(
 
     private fun notifyMethodCall(event: BackInTimeDebuggableInstanceEvent.MethodCall): BackInTimeDebugServiceEvent = BackInTimeDebugServiceEvent.NotifyMethodCall(
         instanceUUID = event.instance.backInTimeInstanceUUID,
-        methodName = event.methodName,
+        methodSignature = event.methodSignature,
         methodCallUUID = event.methodCallId,
         calledAt = Clock.System.now().epochSeconds,
-        ownerClassFqName = event.ownerClassFqName,
     )
 
     private fun notifyPropertyChanged(event: BackInTimeDebuggableInstanceEvent.PropertyValueChange): BackInTimeDebugServiceEvent {
         return BackInTimeDebugServiceEvent.NotifyValueChange(
             instanceUUID = event.instance.backInTimeInstanceUUID,
-            propertyName = event.propertyName,
-            ownerClassFqName = event.ownerClassFqName,
             value = event.propertyValue,
+            propertySignature = event.propertySignature,
             methodCallUUID = event.methodCallId,
         )
     }
@@ -162,22 +159,16 @@ class BackInTimeDebugServiceImpl(
     /**
      * force update the state of a property. This method can be used for back-in-time debugging.
      * @param instanceId the identifier for the property owner class
-     * @param propertyOwnerClassName the full-qualified class name of the property owner class.
-     * @param propertyName the name of the target property.
-     * @param value Json-encoded value which will be assigned to the property.
+     * @param propertySignature the signature of the target property.
+     * @param jsonValue Json-encoded value which will be assigned to the property.
      */
     private fun forceSetValue(
         instanceId: String,
-        propertyOwnerClassName: String,
-        propertyName: String,
-        value: String,
+        propertySignature: String,
+        jsonValue: String,
     ) {
         val targetInstance = instanceManager.getInstanceById(instanceId) ?: return
-        targetInstance.forceSetValue(
-            propertyOwnerClassFqName = propertyOwnerClassName,
-            propertyName = propertyName,
-            value = value,
-        )
+        targetInstance.forceSetValue(propertySignature = propertySignature, jsonValue = jsonValue)
     }
 
     private fun error(event: BackInTimeDebuggableInstanceEvent.Error): BackInTimeDebugServiceEvent {

--- a/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/BackInTimeDebugServiceImpl.kt
+++ b/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/BackInTimeDebugServiceImpl.kt
@@ -128,8 +128,8 @@ class BackInTimeDebugServiceImpl(
         instanceManager.register(event.instance)
         return BackInTimeDebugServiceEvent.RegisterInstance(
             instanceUUID = event.instance.backInTimeInstanceUUID,
-            className = event.classSignature,
-            superClassName = event.superClassSignature,
+            classSignature = event.classSignature,
+            superClassSignature = event.superClassSignature,
             properties = event.properties,
             registeredAt = Clock.System.now().epochSeconds,
         )

--- a/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/BackInTimeDebugServiceImpl.kt
+++ b/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/BackInTimeDebugServiceImpl.kt
@@ -129,8 +129,8 @@ class BackInTimeDebugServiceImpl(
         instanceManager.register(event.instance)
         return BackInTimeDebugServiceEvent.RegisterInstance(
             instanceUUID = event.instance.backInTimeInstanceUUID,
-            className = event.className,
-            superClassName = event.superClassName,
+            className = event.classSignature,
+            superClassName = event.superClassSignature,
             properties = event.properties,
             registeredAt = Clock.System.now().epochSeconds,
         )

--- a/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/BackInTimeDebuggable.kt
+++ b/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/BackInTimeDebuggable.kt
@@ -4,5 +4,5 @@ interface BackInTimeDebuggable {
     val backInTimeInstanceUUID: String
     val backInTimeInitializedPropertyMap: MutableMap<String, Boolean>
 
-    fun forceSetValue(propertyOwnerClassFqName: String, propertyName: String, value: String)
+    fun forceSetValue(propertySignature: String, jsonValue: String)
 }

--- a/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/event/BackInTimeDebuggableInstanceEvent.kt
+++ b/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/event/BackInTimeDebuggableInstanceEvent.kt
@@ -10,14 +10,14 @@ sealed interface BackInTimeDebuggableInstanceEvent {
     /**
      * Register an instance to the debugService
      * @param instance the reference to the instance
-     * @param className the FqName of the class
-     * @param superClassName the FqName of the super class
+     * @param classSignature the signature of the class (same as classId)
+     * @param superClassSignature the signature of the super class (same as classId)
      * @param properties the list of property info
      */
     data class RegisterTarget(
         val instance: BackInTimeDebuggable,
-        val className: String,
-        val superClassName: String,
+        val classSignature: String,
+        val superClassSignature: String,
         val properties: List<PropertyInfo>,
     ) : BackInTimeDebuggableInstanceEvent
 

--- a/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/event/BackInTimeDebuggableInstanceEvent.kt
+++ b/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/event/BackInTimeDebuggableInstanceEvent.kt
@@ -36,27 +36,25 @@ sealed interface BackInTimeDebuggableInstanceEvent {
      * Notify that a method is called
      * @param instance the reference to the instance
      * @param methodCallId the unique id of the method call
-     * @param methodName the name of the method
+     * @param methodSignature the signature of the method. See [com.kitakkun.backintime.compiler.backend.utils.signatureForBackInTimeDebugger] for details.
      */
     data class MethodCall(
         val instance: BackInTimeDebuggable,
-        val ownerClassFqName: String,
         val methodCallId: String,
-        val methodName: String,
+        val methodSignature: String,
     ) : BackInTimeDebuggableInstanceEvent
 
     /**
      * Notify that a property value is changed
      * @param instance the reference to the instance
      * @param methodCallId the unique id of the method call
-     * @param propertyName the name of the property.
+     * @param propertySignature the signature of the property. See [com.kitakkun.backintime.compiler.backend.utils.signatureForBackInTimeDebugger] for details.
      * @param propertyValue the serialized value of the property
      */
     data class PropertyValueChange(
         val instance: BackInTimeDebuggable,
         val methodCallId: String,
-        val ownerClassFqName: String,
-        val propertyName: String,
+        val propertySignature: String,
         val propertyValue: String,
     ) : BackInTimeDebuggableInstanceEvent
 

--- a/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/internal/CaptureUtils.kt
+++ b/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/internal/CaptureUtils.kt
@@ -7,7 +7,6 @@ import com.kitakkun.backintime.core.runtime.BackInTimeDebuggable
 @BackInTimeCompilerInternalApi
 internal inline fun <reified T : Any?> captureThenReturnValue(
     instance: BackInTimeDebuggable,
-    ownerClassFqName: String,
     methodInvocationId: String,
     propertyFqName: String,
     propertyValue: T,
@@ -17,7 +16,6 @@ internal inline fun <reified T : Any?> captureThenReturnValue(
         methodInvocationId = methodInvocationId,
         propertyFqName = propertyFqName,
         propertyValue = propertyValue,
-        ownerClassFqName = ownerClassFqName,
     )
     return propertyValue
 }

--- a/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/internal/CaptureUtils.kt
+++ b/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/internal/CaptureUtils.kt
@@ -8,13 +8,13 @@ import com.kitakkun.backintime.core.runtime.BackInTimeDebuggable
 internal inline fun <reified T : Any?> captureThenReturnValue(
     instance: BackInTimeDebuggable,
     methodInvocationId: String,
-    propertyFqName: String,
+    propertySignature: String,
     propertyValue: T,
 ): T {
     reportPropertyValueChange(
         instance = instance,
         methodInvocationId = methodInvocationId,
-        propertyFqName = propertyFqName,
+        propertySignature = propertySignature,
         propertyValue = propertyValue,
     )
     return propertyValue

--- a/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/internal/EventReportUtils.kt
+++ b/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/internal/EventReportUtils.kt
@@ -27,22 +27,19 @@ internal fun reportInstanceRegistration(
 @BackInTimeCompilerInternalApi
 internal fun reportMethodInvocation(
     instance: BackInTimeDebuggable,
-    ownerClassFqName: String,
     methodInvocationId: String,
     methodName: String,
 ) = getBackInTimeDebugService().processInstanceEvent(
     BackInTimeDebuggableInstanceEvent.MethodCall(
         instance = instance,
         methodCallId = methodInvocationId,
-        methodName = methodName,
-        ownerClassFqName = ownerClassFqName,
+        methodSignature = methodName,
     ),
 )
 
 @BackInTimeCompilerInternalApi
 internal inline fun <reified T> reportPropertyValueChange(
     instance: BackInTimeDebuggable,
-    ownerClassFqName: String,
     methodInvocationId: String,
     propertyFqName: String,
     propertyValue: T,
@@ -53,9 +50,8 @@ internal inline fun <reified T> reportPropertyValueChange(
             BackInTimeDebuggableInstanceEvent.PropertyValueChange(
                 instance = instance,
                 methodCallId = methodInvocationId,
-                propertyName = propertyFqName,
+                propertySignature = propertyFqName,
                 propertyValue = backInTimeJson.encodeToString(propertyValue),
-                ownerClassFqName = ownerClassFqName,
             ),
         )
     } catch (e: Throwable) {

--- a/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/internal/EventReportUtils.kt
+++ b/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/internal/EventReportUtils.kt
@@ -18,8 +18,8 @@ internal fun reportInstanceRegistration(
 ) = getBackInTimeDebugService().processInstanceEvent(
     BackInTimeDebuggableInstanceEvent.RegisterTarget(
         instance = instance,
-        className = className,
-        superClassName = superClassName,
+        classSignature = className,
+        superClassSignature = superClassName,
         properties = properties,
     ),
 )

--- a/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/internal/EventReportUtils.kt
+++ b/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/internal/EventReportUtils.kt
@@ -12,14 +12,14 @@ import kotlinx.serialization.encodeToString
 @BackInTimeCompilerInternalApi
 internal fun reportInstanceRegistration(
     instance: BackInTimeDebuggable,
-    className: String,
-    superClassName: String,
+    classSignature: String,
+    superClassSignature: String,
     properties: List<PropertyInfo>,
 ) = getBackInTimeDebugService().processInstanceEvent(
     BackInTimeDebuggableInstanceEvent.RegisterTarget(
         instance = instance,
-        classSignature = className,
-        superClassSignature = superClassName,
+        classSignature = classSignature,
+        superClassSignature = superClassSignature,
         properties = properties,
     ),
 )
@@ -28,12 +28,12 @@ internal fun reportInstanceRegistration(
 internal fun reportMethodInvocation(
     instance: BackInTimeDebuggable,
     methodInvocationId: String,
-    methodName: String,
+    methodSignature: String,
 ) = getBackInTimeDebugService().processInstanceEvent(
     BackInTimeDebuggableInstanceEvent.MethodCall(
         instance = instance,
         methodCallId = methodInvocationId,
-        methodSignature = methodName,
+        methodSignature = methodSignature,
     ),
 )
 
@@ -41,7 +41,7 @@ internal fun reportMethodInvocation(
 internal inline fun <reified T> reportPropertyValueChange(
     instance: BackInTimeDebuggable,
     methodInvocationId: String,
-    propertyFqName: String,
+    propertySignature: String,
     propertyValue: T,
 ) {
     val service = getBackInTimeDebugService()
@@ -50,7 +50,7 @@ internal inline fun <reified T> reportPropertyValueChange(
             BackInTimeDebuggableInstanceEvent.PropertyValueChange(
                 instance = instance,
                 methodCallId = methodInvocationId,
-                propertySignature = propertyFqName,
+                propertySignature = propertySignature,
                 propertyValue = backInTimeJson.encodeToString(propertyValue),
             ),
         )

--- a/core/websocket/event/src/commonMain/kotlin/com/kitakkun/backintime/core/websocket/event/BackInTimeDebugServiceEvent.kt
+++ b/core/websocket/event/src/commonMain/kotlin/com/kitakkun/backintime/core/websocket/event/BackInTimeDebugServiceEvent.kt
@@ -5,6 +5,7 @@ package com.kitakkun.backintime.core.websocket.event
 
 import com.kitakkun.backintime.core.websocket.event.model.PropertyInfo
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 
@@ -22,7 +23,7 @@ sealed class BackInTimeDebugServiceEvent {
         val classSignature: String,
         val superClassSignature: String,
         val properties: List<PropertyInfo>,
-        val registeredAt: Long,
+        val registeredAt: Int,
     ) : BackInTimeDebugServiceEvent()
 
     @Serializable
@@ -38,7 +39,7 @@ sealed class BackInTimeDebugServiceEvent {
         val instanceUUID: String,
         val methodSignature: String,
         val methodCallUUID: String,
-        val calledAt: Long,
+        val calledAt: Int,
     ) : BackInTimeDebugServiceEvent()
 
     data class RegisterRelationship(
@@ -55,4 +56,16 @@ sealed class BackInTimeDebugServiceEvent {
     data class Error(
         val message: String,
     ) : BackInTimeDebugServiceEvent()
+
+    companion object {
+        // fixme: same as backInTimeJson defined in the runtime library.
+        private val backInTimeJson = Json {
+            encodeDefaults = true
+            explicitNulls = true
+        }
+
+        fun fromJsonString(jsonString: String): BackInTimeDebugServiceEvent {
+            return backInTimeJson.decodeFromString<BackInTimeDebugServiceEvent>(jsonString)
+        }
+    }
 }

--- a/core/websocket/event/src/commonMain/kotlin/com/kitakkun/backintime/core/websocket/event/BackInTimeDebugServiceEvent.kt
+++ b/core/websocket/event/src/commonMain/kotlin/com/kitakkun/backintime/core/websocket/event/BackInTimeDebugServiceEvent.kt
@@ -28,8 +28,7 @@ sealed class BackInTimeDebugServiceEvent {
     @Serializable
     data class NotifyValueChange(
         val instanceUUID: String,
-        val ownerClassFqName: String,
-        val propertyName: String,
+        val propertySignature: String,
         val value: String,
         val methodCallUUID: String,
     ) : BackInTimeDebugServiceEvent()
@@ -37,8 +36,7 @@ sealed class BackInTimeDebugServiceEvent {
     @Serializable
     data class NotifyMethodCall(
         val instanceUUID: String,
-        val ownerClassFqName: String,
-        val methodName: String,
+        val methodSignature: String,
         val methodCallUUID: String,
         val calledAt: Long,
     ) : BackInTimeDebugServiceEvent()

--- a/core/websocket/event/src/commonMain/kotlin/com/kitakkun/backintime/core/websocket/event/BackInTimeDebugServiceEvent.kt
+++ b/core/websocket/event/src/commonMain/kotlin/com/kitakkun/backintime/core/websocket/event/BackInTimeDebugServiceEvent.kt
@@ -19,8 +19,8 @@ sealed class BackInTimeDebugServiceEvent {
     @Serializable
     data class RegisterInstance(
         val instanceUUID: String,
-        val className: String,
-        val superClassName: String,
+        val classSignature: String,
+        val superClassSignature: String,
         val properties: List<PropertyInfo>,
         val registeredAt: Long,
     ) : BackInTimeDebugServiceEvent()

--- a/core/websocket/event/src/commonMain/kotlin/com/kitakkun/backintime/core/websocket/event/BackInTimeDebuggerEvent.kt
+++ b/core/websocket/event/src/commonMain/kotlin/com/kitakkun/backintime/core/websocket/event/BackInTimeDebuggerEvent.kt
@@ -22,10 +22,9 @@ sealed class BackInTimeDebuggerEvent {
 
     @Serializable
     data class ForceSetPropertyValue(
-        val instanceUUID: String,
-        val ownerClassFqName: String,
-        val propertyName: String,
-        val value: String,
+        val targetInstanceId: String,
+        val propertySignature: String,
+        val jsonValue: String,
     ) : BackInTimeDebuggerEvent()
 
     @Serializable

--- a/core/websocket/event/src/commonMain/kotlin/com/kitakkun/backintime/core/websocket/event/BackInTimeDebuggerEvent.kt
+++ b/core/websocket/event/src/commonMain/kotlin/com/kitakkun/backintime/core/websocket/event/BackInTimeDebuggerEvent.kt
@@ -4,6 +4,8 @@
 package com.kitakkun.backintime.core.websocket.event
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 
@@ -31,4 +33,16 @@ sealed class BackInTimeDebuggerEvent {
     data class Error(
         val message: String,
     ) : BackInTimeDebuggerEvent()
+
+    companion object {
+        // fixme: same as backInTimeJson defined in the runtime library.
+        private val backInTimeJson = Json {
+            encodeDefaults = true
+            explicitNulls = true
+        }
+
+        fun toJsonString(event: BackInTimeDebuggerEvent): String {
+            return backInTimeJson.encodeToString(event)
+        }
+    }
 }

--- a/core/websocket/event/src/commonMain/kotlin/com/kitakkun/backintime/core/websocket/event/model/PropertyInfo.kt
+++ b/core/websocket/event/src/commonMain/kotlin/com/kitakkun/backintime/core/websocket/event/model/PropertyInfo.kt
@@ -1,7 +1,11 @@
 package com.kitakkun.backintime.core.websocket.event.model
 
 import kotlinx.serialization.Serializable
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
 
+@OptIn(ExperimentalJsExport::class)
+@JsExport
 @Serializable
 data class PropertyInfo(
     val signature: String,

--- a/core/websocket/event/src/commonMain/kotlin/com/kitakkun/backintime/core/websocket/event/model/PropertyInfo.kt
+++ b/core/websocket/event/src/commonMain/kotlin/com/kitakkun/backintime/core/websocket/event/model/PropertyInfo.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class PropertyInfo(
-    val name: String,
+    val signature: String,
     val debuggable: Boolean,
     val isDebuggableStateHolder: Boolean,
     val propertyType: String,

--- a/flipper-plugin/src/__tests__/test.incomingEvents.tsx
+++ b/flipper-plugin/src/__tests__/test.incomingEvents.tsx
@@ -3,37 +3,37 @@ import * as Plugin from '..';
 import {InstanceInfo} from "../data/InstanceInfo";
 import {AppState} from "../reducer/appReducer";
 import {ClassInfo} from "../data/ClassInfo";
-import {MethodCallInfo} from "../data/MethodCallInfo";
-import {com} from "backintime-websocket-event";
-import NotifyMethodCall = com.kitakkun.backintime.core.websocket.event.BackInTimeDebugServiceEvent.NotifyMethodCall;
-import NotifyValueChange = com.kitakkun.backintime.core.websocket.event.BackInTimeDebugServiceEvent.NotifyValueChange;
 
 test(`register event`, () => {
   const {instance, sendEvent} = TestUtils.startPlugin(Plugin);
   const store = instance.store;
 
-  sendEvent("register", {
-    instanceUUID: "7fd43b42-f951-4307-a997-85f6074c17c9",
-    classSignature: "com/example/DummyViewModel",
-    superClassSignature: "unknown",
-    // @ts-ignore
-    properties: [
-      {
-        signature: "com/example/DummyViewModel.hoge",
-        debuggable: true,
-        isDebuggableStateHolder: false,
-        propertyType: "kotlin/String",
-        valueType: "kotlin/String"
-      },
-      {
-        signature: "com/example/DummyViewModel.fuga",
-        debuggable: false,
-        isDebuggableStateHolder: false,
-        propertyType: "kotlin/String",
-        valueType: "kotlin/String"
-      }
-    ],
-    registeredAt: 1619813420,
+  sendEvent("appEvent", {
+    payload: `
+    {
+      "type": "com.kitakkun.backintime.core.websocket.event.BackInTimeDebugServiceEvent.RegisterInstance",
+      "instanceUUID": "7fd43b42-f951-4307-a997-85f6074c17c9",
+      "classSignature": "com/example/DummyViewModel",
+      "superClassSignature": "unknown",
+      "properties": [
+          {
+              "signature": "com/example/DummyViewModel.hoge",
+              "debuggable": true,
+              "isDebuggableStateHolder": false,
+              "propertyType": "kotlin/String",
+              "valueType": "kotlin/String"
+          },
+          {
+              "signature": "com/example/DummyViewModel.fuga",
+              "debuggable": false,
+              "isDebuggableStateHolder": false,
+              "propertyType": "kotlin/String",
+              "valueType": "kotlin/String"
+          }
+      ],
+      "registeredAt": 1619813420
+    }
+    `
   });
 
   const state = store.getState().app as AppState;
@@ -65,62 +65,4 @@ test(`register event`, () => {
       }
     ]
   } as ClassInfo);
-});
-
-test(`notifyMethodCall event`, () => {
-  const {instance, sendEvent} = TestUtils.startPlugin(Plugin);
-  const store = instance.store;
-
-  sendEvent("notifyMethodCall", {
-    methodSignature: "com/example/MyClass.hoge():kotlin/Unit",
-    instanceUUID: "7fd43b42-f951-4307-a997-85f6074c17c9",
-    methodCallUUID: "jf245181-8d9f-4d9e-9a7b-1a7f4b6f0b3e",
-    calledAt: 1619813420,
-  } as NotifyMethodCall);
-
-  const state = store.getState().app as AppState;
-
-  expect(state.methodCallInfoList[0]).toEqual({
-    instanceUUID: "7fd43b42-f951-4307-a997-85f6074c17c9",
-    methodSignature: "com/example/MyClass.hoge():kotlin/Unit",
-    callUUID: "jf245181-8d9f-4d9e-9a7b-1a7f4b6f0b3e",
-    calledAt: 1619813420,
-    valueChanges: [],
-  } as MethodCallInfo);
-});
-
-test(`notifyValueChange event`, () => {
-  const {instance, sendEvent} = TestUtils.startPlugin(Plugin);
-  const store = instance.store;
-
-  const instanceUUID = "7fd43b42-f951-4307-a997-85f6074c17c9";
-  const methodCallUUID = "jf245181-8d9f-4d9e-9a7b-1a7f4b6f0b3e";
-  const calledAt = 1619813420;
-
-  sendEvent("notifyMethodCall", {
-    methodSignature: "com/example/MyClass.hoge():kotlin/Unit",
-    instanceUUID: instanceUUID,
-    methodCallUUID: methodCallUUID,
-    calledAt: calledAt,
-  } as NotifyMethodCall);
-
-  sendEvent("notifyValueChange", {
-    instanceUUID: instanceUUID,
-    propertySignature: "com/example/MyClass.hoge",
-    value: "fuga",
-    methodCallUUID: methodCallUUID,
-  } as NotifyValueChange);
-
-  expect(store.getState().app.methodCallInfoList[0]).toEqual({
-    instanceUUID: instanceUUID,
-    methodSignature: "com/example/MyClass.hoge():kotlin/Unit",
-    callUUID: methodCallUUID,
-    calledAt: calledAt,
-    valueChanges: [
-      {
-        propertySignature: "com/example/MyClass.hoge",
-        value: "fuga",
-      }
-    ],
-  } as MethodCallInfo);
 });

--- a/flipper-plugin/src/__tests__/test.incomingEvents.tsx
+++ b/flipper-plugin/src/__tests__/test.incomingEvents.tsx
@@ -47,7 +47,7 @@ test(`register event`, () => {
 
   expect(state.classInfoList[0]).toEqual({
     classSignature: "com/example/DummyViewModel",
-    superClassName: "unknown",
+    superClassSignature: "unknown",
     properties: [
       {
         signature: "com/example/DummyViewModel.hoge",

--- a/flipper-plugin/src/__tests__/test.incomingEvents.tsx
+++ b/flipper-plugin/src/__tests__/test.incomingEvents.tsx
@@ -7,7 +7,6 @@ import {MethodCallInfo} from "../data/MethodCallInfo";
 import {com} from "backintime-websocket-event";
 import NotifyMethodCall = com.kitakkun.backintime.core.websocket.event.BackInTimeDebugServiceEvent.NotifyMethodCall;
 import NotifyValueChange = com.kitakkun.backintime.core.websocket.event.BackInTimeDebugServiceEvent.NotifyValueChange;
-import RegisterInstance = com.kitakkun.backintime.core.websocket.event.BackInTimeDebugServiceEvent.RegisterInstance;
 
 test(`register event`, () => {
   const {instance, sendEvent} = TestUtils.startPlugin(Plugin);

--- a/flipper-plugin/src/__tests__/test.incomingEvents.tsx
+++ b/flipper-plugin/src/__tests__/test.incomingEvents.tsx
@@ -39,23 +39,23 @@ test(`register event`, () => {
 
   expect(state.instanceInfoList[0]).toEqual({
     uuid: "7fd43b42-f951-4307-a997-85f6074c17c9",
-    className: "com.example.DummyViewModel",
+    classSignature: "com.example.DummyViewModel",
     alive: true,
     registeredAt: 1619813420,
   } as InstanceInfo);
 
   expect(state.classInfoList[0]).toEqual({
-    name: "com.example.DummyViewModel",
+    classSignature: "com.example.DummyViewModel",
     properties: [
       {
-        name: "hoge",
+        signature: "hoge",
         debuggable: true,
         isDebuggableStateHolder: false,
         type: "java.lang.String",
         valueType: "java.lang.String"
       },
       {
-        name: "fuga",
+        signature: "fuga",
         debuggable: false,
         isDebuggableStateHolder: false,
         type: "java.lang.String",
@@ -82,7 +82,7 @@ test(`notifyMethodCall event`, () => {
   expect(state.methodCallInfoList[0]).toEqual({
     instanceUUID: "7fd43b42-f951-4307-a997-85f6074c17c9",
     ownerClassFqName: "com.example.MyClass",
-    methodName: "hoge",
+    methodSignature: "hoge",
     callUUID: "jf245181-8d9f-4d9e-9a7b-1a7f4b6f0b3e",
     calledAt: 1619813420,
     valueChanges: [],
@@ -116,13 +116,13 @@ test(`notifyValueChange event`, () => {
   expect(store.getState().app.methodCallInfoList[0]).toEqual({
     ownerClassFqName: "com.example.MyClass",
     instanceUUID: instanceUUID,
-    methodName: "hoge",
+    methodSignature: "hoge",
     callUUID: methodCallUUID,
     calledAt: calledAt,
     valueChanges: [
       {
         ownerClassFqName: "com.example.MyClass",
-        propertyName: "hoge",
+        propertySignature: "hoge",
         value: "fuga",
       }
     ],

--- a/flipper-plugin/src/__tests__/test.incomingEvents.tsx
+++ b/flipper-plugin/src/__tests__/test.incomingEvents.tsx
@@ -7,6 +7,7 @@ import {MethodCallInfo} from "../data/MethodCallInfo";
 import {com} from "backintime-websocket-event";
 import NotifyMethodCall = com.kitakkun.backintime.core.websocket.event.BackInTimeDebugServiceEvent.NotifyMethodCall;
 import NotifyValueChange = com.kitakkun.backintime.core.websocket.event.BackInTimeDebugServiceEvent.NotifyValueChange;
+import RegisterInstance = com.kitakkun.backintime.core.websocket.event.BackInTimeDebugServiceEvent.RegisterInstance;
 
 test(`register event`, () => {
   const {instance, sendEvent} = TestUtils.startPlugin(Plugin);
@@ -14,22 +15,23 @@ test(`register event`, () => {
 
   sendEvent("register", {
     instanceUUID: "7fd43b42-f951-4307-a997-85f6074c17c9",
-    className: "com.example.DummyViewModel",
+    classSignature: "com/example/DummyViewModel",
+    superClassSignature: "unknown",
     // @ts-ignore
     properties: [
       {
-        name: "hoge",
+        signature: "com/example/DummyViewModel.hoge",
         debuggable: true,
         isDebuggableStateHolder: false,
-        propertyType: "java.lang.String",
-        valueType: "java.lang.String"
+        propertyType: "kotlin/String",
+        valueType: "kotlin/String"
       },
       {
-        name: "fuga",
+        signature: "com/example/DummyViewModel.fuga",
         debuggable: false,
         isDebuggableStateHolder: false,
-        propertyType: "java.lang.String",
-        valueType: "java.lang.String"
+        propertyType: "kotlin/String",
+        valueType: "kotlin/String"
       }
     ],
     registeredAt: 1619813420,
@@ -39,27 +41,28 @@ test(`register event`, () => {
 
   expect(state.instanceInfoList[0]).toEqual({
     uuid: "7fd43b42-f951-4307-a997-85f6074c17c9",
-    classSignature: "com.example.DummyViewModel",
+    classSignature: "com/example/DummyViewModel",
     alive: true,
     registeredAt: 1619813420,
   } as InstanceInfo);
 
   expect(state.classInfoList[0]).toEqual({
-    classSignature: "com.example.DummyViewModel",
+    classSignature: "com/example/DummyViewModel",
+    superClassName: "unknown",
     properties: [
       {
-        signature: "hoge",
+        signature: "com/example/DummyViewModel.hoge",
         debuggable: true,
         isDebuggableStateHolder: false,
-        type: "java.lang.String",
-        valueType: "java.lang.String"
+        propertyType: "kotlin/String",
+        valueType: "kotlin/String"
       },
       {
-        signature: "fuga",
+        signature: "com/example/DummyViewModel.fuga",
         debuggable: false,
         isDebuggableStateHolder: false,
-        type: "java.lang.String",
-        valueType: "java.lang.String"
+        propertyType: "kotlin/String",
+        valueType: "kotlin/String"
       }
     ]
   } as ClassInfo);
@@ -70,8 +73,7 @@ test(`notifyMethodCall event`, () => {
   const store = instance.store;
 
   sendEvent("notifyMethodCall", {
-    methodName: "hoge",
-    ownerClassFqName: "com.example.MyClass",
+    methodSignature: "com/example/MyClass.hoge():kotlin/Unit",
     instanceUUID: "7fd43b42-f951-4307-a997-85f6074c17c9",
     methodCallUUID: "jf245181-8d9f-4d9e-9a7b-1a7f4b6f0b3e",
     calledAt: 1619813420,
@@ -81,8 +83,7 @@ test(`notifyMethodCall event`, () => {
 
   expect(state.methodCallInfoList[0]).toEqual({
     instanceUUID: "7fd43b42-f951-4307-a997-85f6074c17c9",
-    ownerClassFqName: "com.example.MyClass",
-    methodSignature: "hoge",
+    methodSignature: "com/example/MyClass.hoge():kotlin/Unit",
     callUUID: "jf245181-8d9f-4d9e-9a7b-1a7f4b6f0b3e",
     calledAt: 1619813420,
     valueChanges: [],
@@ -98,8 +99,7 @@ test(`notifyValueChange event`, () => {
   const calledAt = 1619813420;
 
   sendEvent("notifyMethodCall", {
-    methodName: "hoge",
-    ownerClassFqName: "com.example.MyClass",
+    methodSignature: "com/example/MyClass.hoge():kotlin/Unit",
     instanceUUID: instanceUUID,
     methodCallUUID: methodCallUUID,
     calledAt: calledAt,
@@ -107,22 +107,19 @@ test(`notifyValueChange event`, () => {
 
   sendEvent("notifyValueChange", {
     instanceUUID: instanceUUID,
-    ownerClassFqName: "com.example.MyClass",
-    propertyName: "hoge",
+    propertySignature: "com/example/MyClass.hoge",
     value: "fuga",
     methodCallUUID: methodCallUUID,
   } as NotifyValueChange);
 
   expect(store.getState().app.methodCallInfoList[0]).toEqual({
-    ownerClassFqName: "com.example.MyClass",
     instanceUUID: instanceUUID,
-    methodSignature: "hoge",
+    methodSignature: "com/example/MyClass.hoge():kotlin/Unit",
     callUUID: methodCallUUID,
     calledAt: calledAt,
     valueChanges: [
       {
-        ownerClassFqName: "com.example.MyClass",
-        propertySignature: "hoge",
+        propertySignature: "com/example/MyClass.hoge",
         value: "fuga",
       }
     ],

--- a/flipper-plugin/src/data/ClassInfo.tsx
+++ b/flipper-plugin/src/data/ClassInfo.tsx
@@ -1,11 +1,11 @@
 export interface ClassInfo {
-  name: string;
+  classSignature: string;
   superClassName: string;
   properties: PropertyInfo[];
 }
 
 export interface PropertyInfo {
-  name: string;
+  signature: string;
   type: string;
   valueType: string;
   debuggable: boolean;

--- a/flipper-plugin/src/data/ClassInfo.tsx
+++ b/flipper-plugin/src/data/ClassInfo.tsx
@@ -1,13 +1,8 @@
+import {com} from "backintime-websocket-event";
+import PropertyInfo = com.kitakkun.backintime.core.websocket.event.model.PropertyInfo;
+
 export interface ClassInfo {
   classSignature: string;
   superClassName: string;
   properties: PropertyInfo[];
-}
-
-export interface PropertyInfo {
-  signature: string;
-  type: string;
-  valueType: string;
-  debuggable: boolean;
-  isDebuggableStateHolder: boolean;
 }

--- a/flipper-plugin/src/data/ClassInfo.tsx
+++ b/flipper-plugin/src/data/ClassInfo.tsx
@@ -3,6 +3,6 @@ import PropertyInfo = com.kitakkun.backintime.core.websocket.event.model.Propert
 
 export interface ClassInfo {
   classSignature: string;
-  superClassName: string;
+  superClassSignature: string;
   properties: PropertyInfo[];
 }

--- a/flipper-plugin/src/data/InstanceInfo.tsx
+++ b/flipper-plugin/src/data/InstanceInfo.tsx
@@ -1,6 +1,6 @@
 export interface InstanceInfo {
   uuid: string;
-  className: string;
+  classSignature: string;
   alive: boolean;
   registeredAt: number;
 }

--- a/flipper-plugin/src/data/MethodCallInfo.tsx
+++ b/flipper-plugin/src/data/MethodCallInfo.tsx
@@ -1,14 +1,12 @@
 export interface MethodCallInfo {
-  ownerClassFqName: string;
   callUUID: string;
   instanceUUID: string;
-  methodName: string;
+  methodSignature: string;
   calledAt: number;
   valueChanges: ValueChangeInfo[];
 }
 
 export interface ValueChangeInfo {
-  ownerClassFqName: string;
-  propertyName: string;
+  propertySignature: string;
   value: string;
 }

--- a/flipper-plugin/src/events/FlipperIncomingEvents.tsx
+++ b/flipper-plugin/src/events/FlipperIncomingEvents.tsx
@@ -1,10 +1,7 @@
-import {com} from "backintime-websocket-event";
-import BackInTimeDebugServiceEvent = com.kitakkun.backintime.core.websocket.event.BackInTimeDebugServiceEvent;
+interface AppEvent {
+  payload: string;
+}
 
 export type IncomingEvents = {
-  register: BackInTimeDebugServiceEvent.RegisterInstance;
-  notifyValueChange: BackInTimeDebugServiceEvent.NotifyValueChange;
-  notifyMethodCall: BackInTimeDebugServiceEvent.NotifyMethodCall;
-  registerRelationship: BackInTimeDebugServiceEvent.RegisterRelationship;
-  checkInstanceAliveResult: BackInTimeDebugServiceEvent.CheckInstanceAliveResult;
+  appEvent: AppEvent;
 };

--- a/flipper-plugin/src/events/FlipperOutgoingEvents.tsx
+++ b/flipper-plugin/src/events/FlipperOutgoingEvents.tsx
@@ -2,16 +2,10 @@ import {com} from "backintime-websocket-event";
 import BackInTimeDebuggerEvent = com.kitakkun.backintime.core.websocket.event.BackInTimeDebuggerEvent;
 import BackInTimeDebugServiceEvent = com.kitakkun.backintime.core.websocket.event.BackInTimeDebugServiceEvent;
 
+interface DebuggerAction {
+  payload: string;
+}
+
 export type OutgoingEvents = {
-  forceSetPropertyValue(event: BackInTimeDebuggerEvent.ForceSetPropertyValue): Promise<any>;
-  refreshInstanceAliveStatus(event: BackInTimeDebuggerEvent.CheckInstanceAlive): Promise<BackInTimeDebugServiceEvent.CheckInstanceAliveResult>;
-}
-
-// FYI https://timmousk.com/blog/typescript-instanceof-interface/
-export const isForceSetPropertyValue = (event: BackInTimeDebuggerEvent): event is BackInTimeDebuggerEvent.ForceSetPropertyValue => {
-  return event.constructor.name == "ForceSetPropertyValue"
-}
-
-export const isCheckInstanceAlive = (event: BackInTimeDebuggerEvent): event is BackInTimeDebuggerEvent.CheckInstanceAlive => {
-  return event.constructor.name == "CheckInstanceAlive"
+  debuggerEvent(action: DebuggerAction): Promise<any>;
 }

--- a/flipper-plugin/src/reducer/appReducer.tsx
+++ b/flipper-plugin/src/reducer/appReducer.tsx
@@ -57,15 +57,7 @@ const appSlice = createSlice({
         classSignature: event.classSignature,
         superClassName: event.superClassSignature,
         // @ts-ignore
-        properties: event.properties.map(property => (
-          {
-            signature: property.signature,
-            type: property.propertyType,
-            valueType: property.valueType,
-            debuggable: property.debuggable,
-            isDebuggableStateHolder: property.isDebuggableStateHolder,
-          }
-        )),
+        properties: event.properties,
       });
     },
     registerRelationship: (state, action: PayloadAction<BackInTimeDebugServiceEvent.RegisterRelationship>) => {

--- a/flipper-plugin/src/reducer/appReducer.tsx
+++ b/flipper-plugin/src/reducer/appReducer.tsx
@@ -56,7 +56,7 @@ const appSlice = createSlice({
       if (existingClassInfo) return;
       state.classInfoList.push({
         classSignature: event.classSignature,
-        superClassName: event.superClassSignature,
+        superClassSignature: event.superClassSignature,
         // need to map value to avoid object freezing restrictions
         // FYI: https://stackoverflow.com/questions/75148897/get-on-proxy-property-items-is-a-read-only-and-non-configurable-data-proper
         properties: event.properties.asJsReadonlyArrayView().map((value) => value) as PropertyInfo[],

--- a/flipper-plugin/src/reducer/appReducer.tsx
+++ b/flipper-plugin/src/reducer/appReducer.tsx
@@ -41,25 +41,25 @@ const appSlice = createSlice({
         // if new instance is registered, add it to instance list
         state.instanceInfoList.push({
           uuid: event.instanceUUID,
-          className: event.className,
+          classSignature: event.classSignature,
           alive: true,
           registeredAt: event.registeredAt,
         });
-      } else if (existingInstanceInfo.className == event.superClassName) {
+      } else if (existingInstanceInfo.classSignature == event.superClassSignature) {
         // if instance is already registered, update its class name
         // because subclass is registered after superclass
-        existingInstanceInfo.className = event.className
+        existingInstanceInfo.classSignature = event.classSignature
       }
       // classInfo registration
-      const existingClassInfo = state.classInfoList.find((info) => info.name == event.className);
+      const existingClassInfo = state.classInfoList.find((info) => info.classSignature == event.classSignature);
       if (existingClassInfo) return;
       state.classInfoList.push({
-        name: event.className,
-        superClassName: event.superClassName,
+        classSignature: event.classSignature,
+        superClassName: event.superClassSignature,
         // @ts-ignore
         properties: event.properties.map(property => (
           {
-            name: property.name,
+            signature: property.signature,
             type: property.propertyType,
             valueType: property.valueType,
             debuggable: property.debuggable,
@@ -85,10 +85,9 @@ const appSlice = createSlice({
     registerMethodCall: (state, action: PayloadAction<BackInTimeDebugServiceEvent.NotifyMethodCall>) => {
       const event = action.payload;
       state.methodCallInfoList.push({
-        ownerClassFqName: event.ownerClassFqName,
         callUUID: event.methodCallUUID,
         instanceUUID: event.instanceUUID,
-        methodName: event.methodName,
+        methodSignature: event.methodSignature,
         calledAt: event.calledAt,
         valueChanges: [],
       });
@@ -98,8 +97,7 @@ const appSlice = createSlice({
       const methodCallInfo = state.methodCallInfoList.find((info) => info.callUUID == event.methodCallUUID);
       if (!methodCallInfo) return;
       methodCallInfo.valueChanges.push({
-        ownerClassFqName: event.ownerClassFqName,
-        propertyName: event.propertyName,
+        propertySignature: event.propertySignature,
         value: event.value,
       });
     },

--- a/flipper-plugin/src/reducer/appReducer.tsx
+++ b/flipper-plugin/src/reducer/appReducer.tsx
@@ -6,6 +6,7 @@ import {DependencyInfo} from "../data/DependencyInfo";
 import {com} from "backintime-websocket-event";
 import BackInTimeDebuggerEvent = com.kitakkun.backintime.core.websocket.event.BackInTimeDebuggerEvent;
 import BackInTimeDebugServiceEvent = com.kitakkun.backintime.core.websocket.event.BackInTimeDebugServiceEvent;
+import PropertyInfo = com.kitakkun.backintime.core.websocket.event.model.PropertyInfo;
 
 export interface AppState {
   activeTabIndex: string;
@@ -56,8 +57,9 @@ const appSlice = createSlice({
       state.classInfoList.push({
         classSignature: event.classSignature,
         superClassName: event.superClassSignature,
-        // @ts-ignore
-        properties: event.properties,
+        // need to map value to avoid object freezing restrictions
+        // FYI: https://stackoverflow.com/questions/75148897/get-on-proxy-property-items-is-a-read-only-and-non-configurable-data-proper
+        properties: event.properties.asJsReadonlyArrayView().map((value) => value) as PropertyInfo[],
       });
     },
     registerRelationship: (state, action: PayloadAction<BackInTimeDebugServiceEvent.RegisterRelationship>) => {

--- a/flipper-plugin/src/view/page/backintime/BackInTimeModalPage.tsx
+++ b/flipper-plugin/src/view/page/backintime/BackInTimeModalPage.tsx
@@ -34,12 +34,11 @@ export function BackInTimeModalPage() {
                   .filter((history) => history.title == "methodCall")
                   .map((history) => history as MethodCallHistoryInfo);
                 const allValueChanges = methodCallHistories.flatMap((history) => history.valueChanges);
-                const propertyValueChanges = distinctBy(allValueChanges.reverse(), (valueChange) => valueChange.ownerClassFqName + valueChange.propertyName);
+                const propertyValueChanges = distinctBy(allValueChanges.reverse(), (valueChange) => valueChange.propertySignature);
                 propertyValueChanges.forEach((info) => {
                   const event = new BackInTimeDebuggerEvent.ForceSetPropertyValue(
                     state.instanceUUID,
-                    info.ownerClassFqName,
-                    info.propertyName,
+                    info.propertySignature,
                     info.value,
                   );
                   dispatch(appActions.forceSetPropertyValue(event));

--- a/flipper-plugin/src/view/page/backintime/BackInTimeSelector.tsx
+++ b/flipper-plugin/src/view/page/backintime/BackInTimeSelector.tsx
@@ -21,7 +21,7 @@ export const backInTimeStateSelector = createSelector(
       title: "register",
       timestamp: instanceInfo?.registeredAt ?? 0,
       subtitle: "uuid: " + instanceInfo?.uuid,
-      description: instanceInfo?.className ?? "",
+      description: instanceInfo?.classSignature ?? "",
     };
 
     const methodCallEvents: HistoryInfo[] = methodCallInfoList
@@ -30,8 +30,8 @@ export const backInTimeStateSelector = createSelector(
         return {
           title: "methodCall",
           timestamp: info.calledAt,
-          subtitle: info.methodName,
-          description: info.valueChanges.map((change) => `${change.propertyName} = ${change.value}`).join(", "),
+          subtitle: info.methodSignature,
+          description: info.valueChanges.map((change) => `${change.propertySignature} = ${change.value}`).join(", "),
           valueChanges: info.valueChanges,
         } as HistoryInfo;
       });

--- a/flipper-plugin/src/view/page/edited_value_emitter/EditAndEmitValueModalPage.tsx
+++ b/flipper-plugin/src/view/page/edited_value_emitter/EditAndEmitValueModalPage.tsx
@@ -18,11 +18,10 @@ export function EditAndEmitValueModalPage() {
     cancelText={"Cancel"}
     okText={"Emit Edited Value"}
     onOk={() => {
-      if (!state.instanceUUID || !state.propertyName || !state.valueType || !state.ownerClassFqName) return;
+      if (!state.instanceUUID || !state.propertySignature || !state.valueType) return;
       const event = new BackInTimeDebuggerEvent.ForceSetPropertyValue(
         state.instanceUUID,
-        state.ownerClassFqName,
-        state.propertyName,
+        state.propertySignature,
         JSON.stringify(state.editingValue),
       );
       dispatch(appActions.forceSetPropertyValue(event));

--- a/flipper-plugin/src/view/page/edited_value_emitter/EditAndEmitValueReducer.tsx
+++ b/flipper-plugin/src/view/page/edited_value_emitter/EditAndEmitValueReducer.tsx
@@ -7,7 +7,7 @@ interface EditAndEmitReducerState {
   editingValue: any;
   open: boolean;
   instanceUUID: string;
-  propertyName: string;
+  propertySignature: string;
 }
 
 const initialState: EditAndEmitReducerState = {
@@ -15,13 +15,13 @@ const initialState: EditAndEmitReducerState = {
   editingValue: undefined,
   open: false,
   instanceUUID: "",
-  propertyName: "",
+  propertySignature: "",
 };
 
 interface EditAndEmitValueNavArgument {
   initialValue: any;
   instanceUUID: string;
-  propertyName: string;
+  propertySignature: string;
 }
 
 const editAndEmitValueSlice = createSlice({
@@ -32,7 +32,7 @@ const editAndEmitValueSlice = createSlice({
       state.initialValue = action.payload.initialValue;
       state.editingValue = action.payload.initialValue;
       state.instanceUUID = action.payload.instanceUUID;
-      state.propertyName = action.payload.propertyName;
+      state.propertySignature = action.payload.propertySignature;
       state.open = true;
     },
     close: (state) => {
@@ -52,13 +52,12 @@ export const editAndEmitValueStateSelector = createSelector(
   [editAndEmitValueReducerStateSelector, classInfoListSelector, instanceInfoListSelector],
   (state, classInfoList, instanceInfoList) => {
     const instanceInfo = instanceInfoList.find((info) => info.uuid == state.instanceUUID);
-    const classInfo = classInfoList.find((info) => info.name == instanceInfo?.className);
-    const valueType = classInfo?.properties.find((property) => property.name == state.propertyName)?.valueType;
+    const classInfo = classInfoList.find((info) => info.classSignature == instanceInfo?.classSignature);
+    const valueType = classInfo?.properties.find((property) => property.signature == state.propertySignature)?.valueType;
 
     return {
       ...state,
       valueType: valueType,
-      ownerClassFqName: classInfo?.name,
     } as EditAndEmitState;
   }
 );

--- a/flipper-plugin/src/view/page/edited_value_emitter/EditAndEmitValueView.tsx
+++ b/flipper-plugin/src/view/page/edited_value_emitter/EditAndEmitValueView.tsx
@@ -8,8 +8,7 @@ export interface EditAndEmitState {
   editingValue: any;
   open: boolean;
   instanceUUID: string;
-  ownerClassFqName: string;
-  propertyName: string;
+  propertySignature: string;
   valueType: string | undefined;
 }
 
@@ -28,7 +27,7 @@ export function EditAndEmitValueView({state, onEdit}: EditAndEmitValueViewProps)
       <Layout.Container>
         <Typography.Title level={5}>Property Info</Typography.Title>
         <Typography.Text>Instance UUID: {state.instanceUUID}</Typography.Text>
-        <Typography.Text>Property Name: {state.propertyName}</Typography.Text>
+        <Typography.Text>Property Name: {state.propertySignature}</Typography.Text>
         <Typography.Text>Value Type: {state.valueType}</Typography.Text>
 
         Note that the value type can not be edited.

--- a/flipper-plugin/src/view/page/instance_list/InstanceListPage.tsx
+++ b/flipper-plugin/src/view/page/instance_list/InstanceListPage.tsx
@@ -18,10 +18,10 @@ export function InstanceListPage() {
     <BackInTimeModalPage/>
     <InstanceListView
       state={state}
-      onSelectProperty={(instanceUUID, propertyName) => {
+      onSelectProperty={(instanceUUID, propertySignature) => {
         dispatch(propertyInspectorActions.openPropertyInspector({
           instanceUUID: instanceUUID,
-          propertyName: propertyName,
+          propertySignature: propertySignature,
         }))
       }}
       onClickRefresh={() => {

--- a/flipper-plugin/src/view/page/instance_list/InstanceListSelector.tsx
+++ b/flipper-plugin/src/view/page/instance_list/InstanceListSelector.tsx
@@ -35,16 +35,16 @@ function resolveInstanceInfo(
   classInfoList: ClassInfo[],
   instanceInfoList: InstanceInfo[],
   dependencyInfoList: DependencyInfo[],
-  className: string,
+  classSignature: string,
   instanceUUID: string,
   allValueChangeEvents: ValueChangeInfo[],
 ): InstanceItem | undefined {
-  const classInfo = classInfoList.find((info) => info.classSignature == className);
+  const classInfo = classInfoList.find((info) => info.classSignature == classSignature);
   if (!classInfo) return;
-  const superTypeInfo = resolveInstanceInfo(classInfoList, instanceInfoList, dependencyInfoList, classInfo.superClassName, instanceUUID, allValueChangeEvents);
+  const superTypeInfo = resolveInstanceInfo(classInfoList, instanceInfoList, dependencyInfoList, classInfo.superClassSignature, instanceUUID, allValueChangeEvents);
   return {
     name: classInfo.classSignature,
-    superClassName: classInfo.superClassName,
+    superClassSignature: classInfo.superClassSignature,
     uuid: instanceUUID,
     properties: classInfo.properties.map((property) => {
       const dependingInstanceUUIDs = dependencyInfoList.find((info) => info.uuid == instanceUUID);

--- a/flipper-plugin/src/view/page/instance_list/InstanceListSelector.tsx
+++ b/flipper-plugin/src/view/page/instance_list/InstanceListSelector.tsx
@@ -17,7 +17,7 @@ export const selectInstanceList = createSelector(
         classInfoList,
         instanceInfoList,
         dependencyInfoList,
-        instance.className,
+        instance.classSignature,
         instance.uuid,
         methodCallInfoList.filter((info) => info.instanceUUID == instance.uuid).flatMap((info) => info.valueChanges)),
     ).filter((instance) => instance != null) as InstanceItem[];
@@ -37,24 +37,24 @@ function resolveInstanceInfo(
   instanceUUID: string,
   allValueChangeEvents: ValueChangeInfo[],
 ): InstanceItem | undefined {
-  const classInfo = classInfoList.find((info) => info.name == className);
+  const classInfo = classInfoList.find((info) => info.classSignature == className);
   if (!classInfo) return;
   const superTypeInfo = resolveInstanceInfo(classInfoList, instanceInfoList, dependencyInfoList, classInfo.superClassName, instanceUUID, allValueChangeEvents);
   return {
-    name: classInfo.name,
+    name: classInfo.classSignature,
     superClassName: classInfo.superClassName,
     uuid: instanceUUID,
     properties: classInfo.properties.map((property) => {
       const dependingInstanceUUIDs = dependencyInfoList.find((info) => info.uuid == instanceUUID);
       const propertyInstanceInfo = dependingInstanceUUIDs?.dependsOn?.map((dependingInstanceUUID) =>
         instanceInfoList.find((info) => info.uuid == dependingInstanceUUID)
-      )?.find((info) => info?.className == property.type);
+      )?.find((info) => info?.classSignature == property.type);
 
       return {
-        name: property.name,
+        signature: property.signature,
         type: property.type,
         debuggable: property.debuggable,
-        eventCount: allValueChangeEvents.filter((event) => event.propertyName == property.name && classInfo.name == event.ownerClassFqName).length,
+        eventCount: allValueChangeEvents.filter((event) => event.propertySignature == property.signature).length,
         stateHolderInstance: propertyInstanceInfo && resolveInstanceInfo(
           classInfoList,
           instanceInfoList,

--- a/flipper-plugin/src/view/page/instance_list/InstanceListSelector.tsx
+++ b/flipper-plugin/src/view/page/instance_list/InstanceListSelector.tsx
@@ -48,18 +48,18 @@ function resolveInstanceInfo(
       const dependingInstanceUUIDs = dependencyInfoList.find((info) => info.uuid == instanceUUID);
       const propertyInstanceInfo = dependingInstanceUUIDs?.dependsOn?.map((dependingInstanceUUID) =>
         instanceInfoList.find((info) => info.uuid == dependingInstanceUUID)
-      )?.find((info) => info?.classSignature == property.type);
+      )?.find((info) => info?.classSignature == property.propertyType);
 
       return {
         signature: property.signature,
-        type: property.type,
+        type: property.propertyType,
         debuggable: property.debuggable,
         eventCount: allValueChangeEvents.filter((event) => event.propertySignature == property.signature).length,
         stateHolderInstance: propertyInstanceInfo && resolveInstanceInfo(
           classInfoList,
           instanceInfoList,
           dependencyInfoList,
-          property.type,
+          property.propertyType,
           propertyInstanceInfo?.uuid,
           allValueChangeEvents,
         ),

--- a/flipper-plugin/src/view/page/instance_list/InstanceListSelector.tsx
+++ b/flipper-plugin/src/view/page/instance_list/InstanceListSelector.tsx
@@ -6,6 +6,8 @@ import {ClassInfo} from "../../../data/ClassInfo";
 import {ValueChangeInfo} from "../../../data/MethodCallInfo";
 import {InstanceInfo} from "../../../data/InstanceInfo";
 import {DependencyInfo} from "../../../data/DependencyInfo";
+import {com} from "backintime-websocket-event";
+import PropertyInfo = com.kitakkun.backintime.core.websocket.event.model.PropertyInfo;
 
 export const selectInstanceList = createSelector(
   [instanceInfoListSelector, classInfoListSelector, methodCallInfoListSelector, persistentStateSelector, dependencyInfoListSelector],
@@ -25,7 +27,7 @@ export const selectInstanceList = createSelector(
     return {
       instances: instances,
       showNonDebuggableProperty: persistentState.showNonDebuggableProperty,
-    } as InstanceListState;
+    };
   }
 );
 
@@ -51,6 +53,8 @@ function resolveInstanceInfo(
       )?.find((info) => info?.classSignature == property.propertyType);
 
       return {
+        // @ts-ignore
+        name: property.signature.split(".").at(-1).toString(),
         signature: property.signature,
         type: property.propertyType,
         debuggable: property.debuggable,
@@ -63,7 +67,7 @@ function resolveInstanceInfo(
           propertyInstanceInfo?.uuid,
           allValueChangeEvents,
         ),
-      } as PropertyItem;
+      };
     }),
     superInstanceItem: superTypeInfo,
   };

--- a/flipper-plugin/src/view/page/instance_list/InstanceListView.tsx
+++ b/flipper-plugin/src/view/page/instance_list/InstanceListView.tsx
@@ -7,7 +7,7 @@ import {InstanceTreeView} from "./InstanceTreeView";
 export interface InstanceItem {
   name: string;
   uuid: string;
-  superClassName: string;
+  superClassSignature: string;
   properties: PropertyItem[];
   superInstanceItem?: InstanceItem;
 }

--- a/flipper-plugin/src/view/page/instance_list/InstanceListView.tsx
+++ b/flipper-plugin/src/view/page/instance_list/InstanceListView.tsx
@@ -13,6 +13,7 @@ export interface InstanceItem {
 }
 
 export interface PropertyItem {
+  name: string;
   signature: string;
   type: string;
   debuggable: boolean;
@@ -27,7 +28,7 @@ export interface InstanceListState {
 
 type InstanceListProps = {
   state: InstanceListState;
-  onSelectProperty: (instanceUUID: string, propertyName: string) => void;
+  onSelectProperty: (instanceUUID: string, propertySignature: string) => void;
   onClickRefresh: () => void;
   onChangeNonDebuggablePropertyVisible: (visible: boolean) => void;
   onClickHistory: (instanceUUID: string) => void;

--- a/flipper-plugin/src/view/page/instance_list/InstanceListView.tsx
+++ b/flipper-plugin/src/view/page/instance_list/InstanceListView.tsx
@@ -13,7 +13,7 @@ export interface InstanceItem {
 }
 
 export interface PropertyItem {
-  name: string;
+  signature: string;
   type: string;
   debuggable: boolean;
   eventCount: number;

--- a/flipper-plugin/src/view/page/instance_list/InstanceTreeView.tsx
+++ b/flipper-plugin/src/view/page/instance_list/InstanceTreeView.tsx
@@ -152,7 +152,7 @@ function instanceItemToTreeDataNode(
     instance.superInstanceItem,
     StateHolderType.SUPERCLASS,
     showNonDebuggableProperty,
-    `${key}/${instance.superClassName}`,
+    `${key}/${instance.superClassSignature}`,
   ) : undefined;
 
   const children = [...stateHolderPropertyNodes, ...normalPropertyNodes];

--- a/flipper-plugin/src/view/page/instance_list/InstanceTreeView.tsx
+++ b/flipper-plugin/src/view/page/instance_list/InstanceTreeView.tsx
@@ -11,7 +11,7 @@ import {History} from "@mui/icons-material";
 interface InstanceTreeViewProps {
   instances: InstanceItem[];
   showNonDebuggableProperty: boolean;
-  onSelectProperty: (instanceUUID: string, propertyName: string) => void;
+  onSelectProperty: (instanceUUID: string, propertySignature: string) => void;
   onClickHistory: (instanceUUID: string) => void;
 }
 
@@ -53,6 +53,7 @@ interface PropertyTreeDataNode extends MyTreeDataNode {
   nodeType: "property";
   instanceUUID: string;
   name: string;
+  signature: string;
   type: string;
   eventCount: number;
   debuggable: boolean;
@@ -78,7 +79,7 @@ export function InstanceTreeView({instances, showNonDebuggableProperty, onSelect
       if (isInstanceTreeDataNode(info.node)) {
         onClickHistory(info.node.uuid);
       } else if (isPropertyTreeDataNode(info.node)) {
-        onSelectProperty(info.node.instanceUUID, info.node.name);
+        onSelectProperty(info.node.instanceUUID, info.node.signature);
       }
     }}
     blockNode
@@ -228,7 +229,8 @@ function normalPropertyTreeNode(property: PropertyItem, key: string, instanceUUI
     nodeType: "property",
     key: `${key}/${property.signature}`,
     instanceUUID: instanceUUID,
-    name: property.signature,
+    signature: property.signature,
+    name: property.name,
     type: property.type,
     eventCount: property.eventCount,
     debuggable: property.debuggable,

--- a/flipper-plugin/src/view/page/instance_list/InstanceTreeView.tsx
+++ b/flipper-plugin/src/view/page/instance_list/InstanceTreeView.tsx
@@ -138,7 +138,7 @@ function instanceItemToTreeDataNode(
         property.stateHolderInstance!,
         StateHolderType.EXTERNAL,
         showNonDebuggableProperty,
-        `${key}/${property.name}`,
+        `${key}/${property.signature}`,
         property,
       )
     );
@@ -185,7 +185,7 @@ function instanceItemToTreeDataNode(
     children: children,
     uuid: instance.uuid,
     name: instance.name,
-    nameAsProperty: instanceAsProperty?.name,
+    nameAsProperty: instanceAsProperty?.signature,
     stateHolderType: stateHolderType,
   }
 }
@@ -226,9 +226,9 @@ function instanceNodeTitle(name: string, uuid: string, stateHolderType: StateHol
 function normalPropertyTreeNode(property: PropertyItem, key: string, instanceUUID: string): PropertyTreeDataNode {
   return {
     nodeType: "property",
-    key: `${key}/${property.name}`,
+    key: `${key}/${property.signature}`,
     instanceUUID: instanceUUID,
-    name: property.name,
+    name: property.signature,
     type: property.type,
     eventCount: property.eventCount,
     debuggable: property.debuggable,

--- a/flipper-plugin/src/view/page/value_emit/ChangedPropertiesView.tsx
+++ b/flipper-plugin/src/view/page/value_emit/ChangedPropertiesView.tsx
@@ -22,14 +22,14 @@ type ValueChangeItem = {
 export function ChangedPropertiesView({classInfo, methodCallInfo, onClickEmitValue, onClickEditAndEmitValue}: ChangedPropertiesViewProps) {
   const dataSource: ValueChangeItem[] = methodCallInfo.valueChanges.map((valueChange) => {
     // FIXME: will not work correctly for the class which has a back-in-time debuggable class as a super class.
-    const property = classInfo.properties.find((property) => property.name === valueChange.propertyName)!;
+    const property = classInfo.properties.find((property) => property.signature === valueChange.propertySignature)!;
     const jsonValue = JSON.parse(valueChange.value);
     return {
       action: <EmitButton
-        onClickEmitValue={() => onClickEmitValue(property.name, valueChange.value)}
-        onClickEditValue={() => onClickEditAndEmitValue(property.name, valueChange.value)}
+        onClickEmitValue={() => onClickEmitValue(property.signature, valueChange.value)}
+        onClickEditValue={() => onClickEditAndEmitValue(property.signature, valueChange.value)}
       />,
-      name: property.name,
+      name: property.signature,
       value: <MyJsonView initialValue={jsonValue} onEdit={null}/>
     };
   });

--- a/flipper-plugin/src/view/page/value_emit/ValueEmitModalPage.tsx
+++ b/flipper-plugin/src/view/page/value_emit/ValueEmitModalPage.tsx
@@ -29,8 +29,8 @@ export function ValueEmitModalPage() {
           onValueEmit={(propertySignature: string, value: string) => {
             const instanceUUID = state.instanceInfo?.uuid;
             const valueType = state.classInfo?.properties.find((property) => property.signature == propertySignature)?.valueType;
-            const className = state.classInfo?.classSignature
-            if (!instanceUUID || !valueType || !className) {
+            const classSignature = state.classInfo?.classSignature
+            if (!instanceUUID || !valueType || !classSignature) {
               return;
             }
             const event = new BackInTimeDebuggerEvent.ForceSetPropertyValue(instanceUUID, propertySignature, value);

--- a/flipper-plugin/src/view/page/value_emit/ValueEmitModalPage.tsx
+++ b/flipper-plugin/src/view/page/value_emit/ValueEmitModalPage.tsx
@@ -26,19 +26,19 @@ export function ValueEmitModalPage() {
       >
         <ValueEmitView
           state={state}
-          onValueEmit={(propertyName: string, value: string) => {
+          onValueEmit={(propertySignature: string, value: string) => {
             const instanceUUID = state.instanceInfo?.uuid;
-            const valueType = state.classInfo?.properties.find((property) => property.name == propertyName)?.valueType;
-            const className = state.classInfo?.name
+            const valueType = state.classInfo?.properties.find((property) => property.signature == propertySignature)?.valueType;
+            const className = state.classInfo?.classSignature
             if (!instanceUUID || !valueType || !className) {
               return;
             }
-            const event = new BackInTimeDebuggerEvent.ForceSetPropertyValue(instanceUUID, className, propertyName, value);
+            const event = new BackInTimeDebuggerEvent.ForceSetPropertyValue(instanceUUID, propertySignature, value);
             dispatch(appActions.forceSetPropertyValue(event));
           }}
-          onEditAndEmitValue={(propertyName: string, value: string) => {
+          onEditAndEmitValue={(propertySignature: string, value: string) => {
             const instanceUUID = state.instanceInfo?.uuid;
-            const valueType = state.classInfo?.properties.find((property) => property.name == propertyName)?.valueType;
+            const valueType = state.classInfo?.properties.find((property) => property.signature == propertySignature)?.valueType;
             if (!instanceUUID || !valueType) {
               return;
             }
@@ -46,7 +46,7 @@ export function ValueEmitModalPage() {
             dispatch(
               editAndEmitValueActions.open({
                 instanceUUID: instanceUUID,
-                propertyName: propertyName,
+                propertySignature: propertySignature,
                 initialValue: parsedValue,
               })
             );

--- a/flipper-plugin/src/view/page/value_emit/ValueEmitReducer.tsx
+++ b/flipper-plugin/src/view/page/value_emit/ValueEmitReducer.tsx
@@ -45,7 +45,7 @@ export const valueEmitStateSelector = createSelector(
   (state, classInfoList, instanceInfoList, methodCallInfoList) => {
     const instanceInfo = instanceInfoList.find((info) => info.uuid == state.instanceUUID);
     const methodCallInfo = methodCallInfoList.find((info) => info.callUUID == state.methodCallUUID);
-    const classInfo = classInfoList.find((info) => info.name == instanceInfo?.className);
+    const classInfo = classInfoList.find((info) => info.classSignature == instanceInfo?.classSignature);
 
     return {
       open: state.open,

--- a/flipper-plugin/src/view/page/value_emit/ValueEmitView.tsx
+++ b/flipper-plugin/src/view/page/value_emit/ValueEmitView.tsx
@@ -30,7 +30,7 @@ export function ValueEmitView({state, onValueEmit, onEditAndEmitValue}: ValueEmi
         methodCallUUID={state.methodCallInfo?.callUUID}
         instanceUUID={state.instanceInfo.uuid}
         calledAt={state.methodCallInfo.calledAt}
-        methodName={state.methodCallInfo.methodName}
+        methodName={state.methodCallInfo.methodSignature}
       />
       <ChangedPropertiesView
         classInfo={state.classInfo}

--- a/flipper-plugin/src/view/sidebar/property_inspector/InstanceDescriptionsView.tsx
+++ b/flipper-plugin/src/view/sidebar/property_inspector/InstanceDescriptionsView.tsx
@@ -15,7 +15,7 @@ export function InstanceDescriptionsView({instanceInfo}: InstanceInfoProps) {
     layout={"horizontal"}
   >
     <Descriptions.Item label={"id"}>{instanceInfo.uuid}</Descriptions.Item>
-    <Descriptions.Item label={"type"}>{instanceInfo.className}</Descriptions.Item>
+    <Descriptions.Item label={"type"}>{instanceInfo.classSignature}</Descriptions.Item>
     <Descriptions.Item label={"registeredAt"}>{instanceInfo.registeredAt}</Descriptions.Item>
     <Descriptions.Item label={"alive"}>{instanceInfo.alive ? "true" : "false"}</Descriptions.Item>
   </Descriptions>;

--- a/flipper-plugin/src/view/sidebar/property_inspector/PropertyDescriptionsView.tsx
+++ b/flipper-plugin/src/view/sidebar/property_inspector/PropertyDescriptionsView.tsx
@@ -1,6 +1,7 @@
 import {Descriptions, Table, Typography} from "antd";
 import React from "react";
-import {PropertyInfo} from "../../../data/ClassInfo";
+import {com} from "backintime-websocket-event";
+import PropertyInfo = com.kitakkun.backintime.core.websocket.event.model.PropertyInfo;
 
 type PropertyInfoTableProps = {
   propertyInfo: PropertyInfo;
@@ -15,7 +16,7 @@ export function PropertyDescriptionsView({propertyInfo}: PropertyInfoTableProps)
     layout={"horizontal"}
   >
     <Descriptions.Item label={"name"}>{propertyInfo.signature}</Descriptions.Item>
-    <Descriptions.Item label={"propertyType"}>{propertyInfo.type}</Descriptions.Item>
+    <Descriptions.Item label={"propertyType"}>{propertyInfo.propertyType}</Descriptions.Item>
     <Descriptions.Item label={"valueType"}>{propertyInfo.valueType}</Descriptions.Item>
     <Descriptions.Item label={"debuggable"}>{propertyInfo.debuggable ? "true" : "false"}</Descriptions.Item>
   </Descriptions>;

--- a/flipper-plugin/src/view/sidebar/property_inspector/PropertyDescriptionsView.tsx
+++ b/flipper-plugin/src/view/sidebar/property_inspector/PropertyDescriptionsView.tsx
@@ -14,7 +14,7 @@ export function PropertyDescriptionsView({propertyInfo}: PropertyInfoTableProps)
     bordered
     layout={"horizontal"}
   >
-    <Descriptions.Item label={"name"}>{propertyInfo.name}</Descriptions.Item>
+    <Descriptions.Item label={"name"}>{propertyInfo.signature}</Descriptions.Item>
     <Descriptions.Item label={"propertyType"}>{propertyInfo.type}</Descriptions.Item>
     <Descriptions.Item label={"valueType"}>{propertyInfo.valueType}</Descriptions.Item>
     <Descriptions.Item label={"debuggable"}>{propertyInfo.debuggable ? "true" : "false"}</Descriptions.Item>

--- a/flipper-plugin/src/view/sidebar/property_inspector/PropertyInspectorStateSelector.tsx
+++ b/flipper-plugin/src/view/sidebar/property_inspector/PropertyInspectorStateSelector.tsx
@@ -33,11 +33,11 @@ export const propertyInspectorStateSelector = createSelector(
   }
 );
 
-function getPropertiesRecursively(classInfoList: ClassInfo[], className: string): PropertyInfo[] {
-  const classInfo = classInfoList.find((info) => info.classSignature == className);
+function getPropertiesRecursively(classInfoList: ClassInfo[], classSignature: string): PropertyInfo[] {
+  const classInfo = classInfoList.find((info) => info.classSignature == classSignature);
   if (!classInfo) return [];
   return [
     ...classInfo.properties,
-    ...getPropertiesRecursively(classInfoList, classInfo.superClassName)
+    ...getPropertiesRecursively(classInfoList, classInfo.superClassSignature)
   ];
 }

--- a/flipper-plugin/src/view/sidebar/property_inspector/PropertyInspectorStateSelector.tsx
+++ b/flipper-plugin/src/view/sidebar/property_inspector/PropertyInspectorStateSelector.tsx
@@ -2,7 +2,9 @@ import {createSelector} from "@reduxjs/toolkit";
 import {classInfoListSelector, instanceInfoListSelector, methodCallInfoListSelector} from "../../../reducer/appReducer";
 import {PropertyInspectorState} from "./PropertyInspectorView";
 import {propertyInspectorReducerStateSelector} from "./propertyInspectorReducer";
-import {ClassInfo, PropertyInfo} from "../../../data/ClassInfo";
+import {ClassInfo} from "../../../data/ClassInfo";
+import {com} from "backintime-websocket-event";
+import PropertyInfo = com.kitakkun.backintime.core.websocket.event.model.PropertyInfo;
 
 export const propertyInspectorStateSelector = createSelector(
   [instanceInfoListSelector, classInfoListSelector, methodCallInfoListSelector, propertyInspectorReducerStateSelector],

--- a/flipper-plugin/src/view/sidebar/property_inspector/PropertyInspectorStateSelector.tsx
+++ b/flipper-plugin/src/view/sidebar/property_inspector/PropertyInspectorStateSelector.tsx
@@ -8,18 +8,18 @@ export const propertyInspectorStateSelector = createSelector(
   [instanceInfoListSelector, classInfoListSelector, methodCallInfoListSelector, propertyInspectorReducerStateSelector],
   (instanceInfoList, classInfoList, methodCallInfoList, state) => {
     const instanceInfo = instanceInfoList.find((info) => info.uuid == state.instanceUUID);
-    const propertyInfo = instanceInfo && getPropertiesRecursively(classInfoList, instanceInfo?.className)
-      .find((info) => info.name == state?.propertyName);
+    const propertyInfo = instanceInfo && getPropertiesRecursively(classInfoList, instanceInfo?.classSignature)
+      .find((info) => info.signature == state?.propertySignature);
 
     const valueChanges = methodCallInfoList.filter((info) =>
       // FIXME: will not work correctly for the class which has a back-in-time debuggable class as a super class.
-      info.instanceUUID == state.instanceUUID && info.valueChanges.some((change) => change.propertyName.split(".").pop() == state.propertyName)
+      info.instanceUUID == state.instanceUUID && info.valueChanges.some((change) => change.propertySignature == state.propertySignature)
     ).map((info) => {
       return {
         methodCallUUID: info.callUUID,
         time: info.calledAt,
         // FIXME: will not work correctly for the class which has a back-in-time debuggable class as a super class.
-        value: [...info.valueChanges].reverse().find((change) => change.propertyName.split(".").pop() == state.propertyName)?.value ?? "",
+        value: [...info.valueChanges].reverse().find((change) => change.propertySignature == state.propertySignature)?.value ?? "",
       }
     });
 
@@ -32,7 +32,7 @@ export const propertyInspectorStateSelector = createSelector(
 );
 
 function getPropertiesRecursively(classInfoList: ClassInfo[], className: string): PropertyInfo[] {
-  const classInfo = classInfoList.find((info) => info.name == className);
+  const classInfo = classInfoList.find((info) => info.classSignature == className);
   if (!classInfo) return [];
   return [
     ...classInfo.properties,

--- a/flipper-plugin/src/view/sidebar/property_inspector/PropertyInspectorView.tsx
+++ b/flipper-plugin/src/view/sidebar/property_inspector/PropertyInspectorView.tsx
@@ -4,7 +4,8 @@ import {PropertyDescriptionsView} from "./PropertyDescriptionsView";
 import {PropertyValueChangesView} from "./PropertyValueChangesView";
 import {Layout, theme} from "flipper-plugin";
 import {InstanceInfo} from "../../../data/InstanceInfo";
-import {PropertyInfo} from "../../../data/ClassInfo";
+import {com} from "backintime-websocket-event";
+import PropertyInfo = com.kitakkun.backintime.core.websocket.event.model.PropertyInfo;
 
 export interface ValueChangeInfo {
   methodCallUUID: string;

--- a/flipper-plugin/src/view/sidebar/property_inspector/propertyInspectorReducer.tsx
+++ b/flipper-plugin/src/view/sidebar/property_inspector/propertyInspectorReducer.tsx
@@ -2,17 +2,17 @@ import {createSlice, PayloadAction} from "@reduxjs/toolkit";
 
 export interface PropertyInspectorReducerState {
   instanceUUID: string;
-  propertyName: string;
+  propertySignature: string;
 }
 
 const initialState: PropertyInspectorReducerState = {
   instanceUUID: "",
-  propertyName: "",
+  propertySignature: "",
 }
 
 export interface PropertyInspectorNavArguments {
   instanceUUID: string;
-  propertyName: string;
+  propertySignature: string;
 }
 
 const propertyInspectorSlice = createSlice({
@@ -21,7 +21,7 @@ const propertyInspectorSlice = createSlice({
   reducers: {
     openPropertyInspector: (state, action: PayloadAction<PropertyInspectorNavArguments>) => {
       state.instanceUUID = action.payload.instanceUUID;
-      state.propertyName = action.payload.propertyName;
+      state.propertySignature = action.payload.propertySignature;
     }
   }
 });


### PR DESCRIPTION
This PR introduces new signatures for distinction of class, functions, and properties.

When reverting property states in the super class, we needed to specify the full-qualified name of the owner class. However, this leads complexity on our codebase.

Since this PR, we simplify the distinction of each declaration by introducing a new signature logic.

## Class signatures

Class signature is same as `classId` we often see in the compiler code.
For example:
```kotlin
package com.example

class A {
    class B
}
```

- The signature for the class `A`: `com/example/A`
- The signature for the class `B`: `com/example/A.B`

## Function signatures

Function signatures are a bit difficult to understand.

Imagine the examples below:
```kotlin
package com.example

fun topLevel() {}

class A {
    fun method(value: Int) {}
    fun Int.extension() {}
}
```

- The signature for the top-level function `topLevel`: `com/example/topLevel():kotlin/Unit`
- The signature for `method`: `com/example/A.method():kotlin/Unit`
- The signature for `Int.extension`: `kotlin/Int com/example/A.extension():kotlin/Unit`

## Property signatures

```kotlin
package com.example

class A {
    val prop: Int = 10
}
```

- The signature for `prop`: `com/example/A.prop`

## Flipper Plugin changes

All declaration names are replaced with new corresponding signatures. Though property names displayed on instances screen remain the same, signatures displayed in the other places will change:

<img width="1613" alt="image" src="https://github.com/user-attachments/assets/8efa508b-5ed1-49a2-a5de-5755b47c4da4" />

