### PR TITLE
Generate Kotlin/JS libraries by preinstall hook

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -29,11 +29,6 @@ jobs:
         with:
           node-version: "21.x"
 
-      - name: generate js library for flipper
-        run: |
-          ./gradlew core:websocket:event:jsNodeProductionLibraryDistribution \
-          tooling:model:jsNodeProductionLibraryDistribution \
-          tooling:flipper-lib:jsNodeProductionLibraryDistribution
       - run: yarn install
         working-directory: flipper-plugin
 

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -60,12 +60,6 @@ jobs:
         with:
           node-version: "21.x"
 
-      - name: generate js library for flipper
-        run: |
-          ./gradlew core:websocket:event:jsNodeProductionLibraryDistribution \
-          tooling:model:jsNodeProductionLibraryDistribution \
-          tooling:flipper-lib:jsNodeProductionLibraryDistribution
-
       - run: yarn install
         working-directory: flipper-plugin
 

--- a/flipper-plugin/package.json
+++ b/flipper-plugin/package.json
@@ -17,7 +17,8 @@
     "prepack": "flipper-pkg lint && flipper-pkg bundle",
     "build": "flipper-pkg bundle",
     "watch": "flipper-pkg bundle --watch",
-    "test": "jest --no-watchman"
+    "test": "jest --no-watchman",
+    "preinstall": "cd .. && ./gradlew jsNodeProductionLibraryDistribution"
   },
   "peerDependencies": {
     "@emotion/styled": "latest",


### PR DESCRIPTION
Trigger `./gradlew jsNodeProductionLibraryDistribution` before `yarn install`.
This may also fix renovate errors when trying to install local Kotllin/JS libraries.