### PR TITLE
Refactor: Make websocket event module independent from model module

### DIFF
--- a/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/BackInTimePluginContext.kt
+++ b/compiler/backend/src/main/core/com/kitakkun/backintime/compiler/backend/BackInTimePluginContext.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
-import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.ir.util.isVararg
 import org.jetbrains.kotlin.javac.resolve.classId
 import org.jetbrains.kotlin.name.CallableId
@@ -38,11 +37,6 @@ class BackInTimePluginContext(
     // capture utils
     val captureThenReturnValueFunctionSymbol by lazy { backintimeNamedFunction(name = "captureThenReturnValue", subpackage = "core.runtime.internal") }
 
-    /**
-     * Used in [com.kitakkun.backintime.compiler.backend.transformer.BackInTimeDebuggableConstructorTransformer]
-     */
-    val propertyInfoClass by lazy { backintimeIrClassSymbol(name = "PropertyInfo", subpackage = "tooling.model") }
-    val propertyInfoClassConstructor = propertyInfoClass.constructors.first { it.owner.isPrimary }
     val listOfFunction by lazy { namedFunction("kotlin.collections", "listOf") { it.owner.valueParameters.size == 1 && it.owner.valueParameters.first().isVararg } }
 
     // kotlinx-serialization

--- a/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/event/BackInTimeDebuggableInstanceEvent.kt
+++ b/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/event/BackInTimeDebuggableInstanceEvent.kt
@@ -1,7 +1,6 @@
 package com.kitakkun.backintime.core.runtime.event
 
 import com.kitakkun.backintime.core.runtime.BackInTimeDebuggable
-import com.kitakkun.backintime.tooling.model.PropertyInfo
 
 /**
  * events inside the BackInTimeDebuggable instance
@@ -18,7 +17,7 @@ sealed interface BackInTimeDebuggableInstanceEvent {
         val instance: BackInTimeDebuggable,
         val classSignature: String,
         val superClassSignature: String,
-        val properties: List<PropertyInfo>,
+        val properties: List<String>,
     ) : BackInTimeDebuggableInstanceEvent
 
     /**

--- a/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/internal/EventReportUtils.kt
+++ b/core/runtime/src/commonMain/kotlin/com/kitakkun/backintime/core/runtime/internal/EventReportUtils.kt
@@ -6,15 +6,13 @@ import com.kitakkun.backintime.core.runtime.BackInTimeDebuggable
 import com.kitakkun.backintime.core.runtime.backInTimeJson
 import com.kitakkun.backintime.core.runtime.event.BackInTimeDebuggableInstanceEvent
 import com.kitakkun.backintime.core.runtime.getBackInTimeDebugService
-import com.kitakkun.backintime.tooling.model.PropertyInfo
-import kotlinx.serialization.encodeToString
 
 @BackInTimeCompilerInternalApi
 internal fun reportInstanceRegistration(
     instance: BackInTimeDebuggable,
     classSignature: String,
     superClassSignature: String,
-    properties: List<PropertyInfo>,
+    properties: List<String>,
 ) = getBackInTimeDebugService().processInstanceEvent(
     BackInTimeDebuggableInstanceEvent.RegisterTarget(
         instance = instance,

--- a/core/websocket/event/build.gradle.kts
+++ b/core/websocket/event/build.gradle.kts
@@ -23,7 +23,6 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(projects.tooling.model)
             implementation(libs.kotlinx.serialization.json)
         }
     }

--- a/core/websocket/event/src/commonMain/kotlin/com/kitakkun/backintime/core/websocket/event/BackInTimeDebugServiceEvent.kt
+++ b/core/websocket/event/src/commonMain/kotlin/com/kitakkun/backintime/core/websocket/event/BackInTimeDebugServiceEvent.kt
@@ -3,7 +3,6 @@
 
 package com.kitakkun.backintime.core.websocket.event
 
-import com.kitakkun.backintime.tooling.model.PropertyInfo
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlin.js.ExperimentalJsExport
@@ -22,7 +21,7 @@ sealed class BackInTimeDebugServiceEvent : BackInTimeWebSocketEvent {
         val instanceUUID: String,
         val classSignature: String,
         val superClassSignature: String,
-        val properties: List<PropertyInfo>,
+        val properties: List<String>,
         val registeredAt: Int,
     ) : BackInTimeDebugServiceEvent()
 

--- a/tooling/flipper-lib/src/commonMain/kotlin/com/kitakkun/backintime/tooling/flipper/FlipperAppStateOwner.kt
+++ b/tooling/flipper-lib/src/commonMain/kotlin/com/kitakkun/backintime/tooling/flipper/FlipperAppStateOwner.kt
@@ -8,6 +8,7 @@ import com.kitakkun.backintime.tooling.model.ClassInfo
 import com.kitakkun.backintime.tooling.model.DependencyInfo
 import com.kitakkun.backintime.tooling.model.InstanceInfo
 import com.kitakkun.backintime.tooling.model.MethodCallInfo
+import com.kitakkun.backintime.tooling.model.PropertyInfo
 import com.kitakkun.backintime.tooling.model.ValueChangeInfo
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -60,7 +61,23 @@ class FlipperAppStateOwnerImpl(
                     }
 
                     val newClassInfoList = if (appState.classInfoList.none { it.classSignature == event.classSignature }) {
-                        appState.classInfoList + ClassInfo(classSignature = event.classSignature, superClassSignature = event.superClassSignature, properties = event.properties)
+                        appState.classInfoList + ClassInfo(
+                            classSignature = event.classSignature,
+                            superClassSignature = event.superClassSignature,
+                            properties = event.properties.map {
+                                /**
+                                 * see [com.kitakkun.backintime.compiler.backend.transformer.capture.BackInTimeDebuggableConstructorTransformer] for details.
+                                 */
+                                val info = it.split(",")
+                                PropertyInfo(
+                                    signature = info[0],
+                                    debuggable = info[1].toBoolean(),
+                                    isDebuggableStateHolder = info[2].toBoolean(),
+                                    propertyType = info[3],
+                                    valueType = info[4],
+                                )
+                            }
+                        )
                     } else {
                         appState.classInfoList
                     }


### PR DESCRIPTION
## Overview
Refactored the implementation to generate a primitive String value instead of constructing the PropertyInfo class within the debugging target app.

## Background and Purpose
This change removes the dependency of the core:websocket:event module on the tooling:model module, improving module independence and simplifying the overall structure.

The most important thing is that it allows `tooling:model` module to depend on `core:websocket:event` module.
 It will make it possible to create the class like below in the `tooling:model` module:
```kotlin
data class Event(
    val payload: BackInTimeWebSocketEvent,
)
```

## Key Changes
- Switched from constructing PropertyInfo instances to generating primitive String values.
- Removed unnecessary dependencies between modules.